### PR TITLE
Fix ABI checking failed on macOS

### DIFF
--- a/src/core/kernel/QvKernelABIChecker.cpp
+++ b/src/core/kernel/QvKernelABIChecker.cpp
@@ -48,7 +48,7 @@ namespace Qv2ray::core::kernel::abi
         }
         else if (quint16 dosMagicMaybe; QDataStream(arr) >> dosMagicMaybe, dosMagicMaybe == 0x4D5Au)
             return { QvKernelABIType::ABI_WIN32, std::nullopt };
-        else if (quint32 machOMagicMaybe; QDataStream(arr) >> machOMagicMaybe, machOMagicMaybe == 0xCAFEBABEu)
+        else if (quint32 machOMagicMaybe; QDataStream(arr) >> machOMagicMaybe, machOMagicMaybe == 0xCFFAEDFEu)
             return { QvKernelABIType::ABI_MACH_O, std::nullopt };
         else
             return { std::nullopt, QObject::tr("cannot deduce the type of core executable file %1").arg(pathCoreExecutable) };


### PR DESCRIPTION
Fix check ABI failed on macOS, because 0xCAFEBABE refers to 32-bit Mach-O, and 32-bit is not supported since Mac OS X v10.7.0, so 64-bit Magic check must be used here, more See https://developer.apple.com/documentation/kernel/mach_header_64/1525718-magic?language=objc for information