### PR TITLE
Add spec file and Makefile for RPM build on Fedora Copr

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,76 @@
+SELF := $(abspath $(lastword $(MAKEFILE_LIST)))
+HERE := $(dir $(SELF))
+export PROJECT_ROOT := $(realpath $(HERE)/..)
+
+RPM_PACKAGE_NAME := qv2ray
+RPM_VERSION := $(shell cat $(PROJECT_ROOT)/makespec/VERSION)
+RPM_RELEASE :=
+RPM_BUILDROOT := default
+
+SPEC_FILE = $(PROJECT_ROOT)/makespec/$(RPM_PACKAGE_NAME).spec
+TARBALL_OUTDIR := $(or $(outdir), $(PROJECT_ROOT)/build/tarball)
+RPM_OUTDIR := $(or $(outdir), $(PROJECT_ROOT)/build/rpm)
+SRPM_OUTDIR :=$(or $(outdir), $(PROJECT_ROOT)/build/srpm)
+export TARBALL_BASENAME = $(RPM_PACKAGE_NAME)-$(RPM_VERSION)
+export TARBALL_OUTDIR_ABS = $(abspath $(TARBALL_OUTDIR))
+
+HAS_GIT := $(shell command -v git 2> /dev/null)
+ifndef HAS_GIT
+deps:
+	dnf -y install git
+else
+deps:
+endif
+
+tarball: deps
+	mkdir -p "$${TARBALL_OUTDIR_ABS}"
+	# archive qv2ray
+	cd $(PROJECT_ROOT) && git archive HEAD --format=tar --prefix="$${TARBALL_BASENAME}/" \
+		-o "$${TARBALL_OUTDIR_ABS}/$${TARBALL_BASENAME}.tar"
+	# archive submodules
+	cd $(PROJECT_ROOT) && git submodule update --init && \
+	    git submodule foreach --quiet 'set -e ;\
+		mkdir -p "$$(dirname -- $${TARBALL_OUTDIR_ABS}/$${path})" ;\
+		git archive HEAD --format=tar \
+			--prefix="$${TARBALL_BASENAME}/$${path}/" \
+			-o "$${TARBALL_OUTDIR_ABS}/$${path}-$${sha1}.tar" ;\
+		tar -n --concatenate --file="$${TARBALL_OUTDIR_ABS}/$${TARBALL_BASENAME}.tar" \
+			"$${TARBALL_OUTDIR_ABS}/$${path}-$${sha1}.tar"'
+	# delete `3rdparty/zxing-cpp/test` from the source tarball
+	tar -f "$${TARBALL_OUTDIR_ABS}/$${TARBALL_BASENAME}.tar" --delete "$${TARBALL_BASENAME}/3rdparty/zxing-cpp/test" || true
+	# compress
+	gzip -c "$${TARBALL_OUTDIR_ABS}/$${TARBALL_BASENAME}.tar" > "$${TARBALL_OUTDIR_ABS}/$${TARBALL_BASENAME}.tar.gz"
+	# clean-up
+	cd $(PROJECT_ROOT) && git submodule foreach --quiet 'rm "$${TARBALL_OUTDIR_ABS}/$${path}-$${sha1}.tar"'
+	rm "$${TARBALL_OUTDIR_ABS}/$${TARBALL_BASENAME}.tar"
+	find "$${TARBALL_OUTDIR_ABS}" -type d -empty -delete
+	# workaround https://pagure.io/copr/copr/issue/1258
+	(id mockbuild && chown mockbuild: -R "$(PROJECT_ROOT)") || true
+
+spec: deps
+	export RPM_RELEASE=$(RPM_RELEASE) ;\
+	if [ -z "$$RPM_RELEASE" ]; then RPM_RELEASE=0.git.$$(git rev-parse --short=7 HEAD)%{?dist}; fi;\
+	sed -e "s/@NAME@/$(RPM_PACKAGE_NAME)/g" \
+		-e "s/@VERSION@/$(RPM_VERSION)/g" \
+		-e "s/@RELEASE@/$${RPM_RELEASE}/g" \
+		-e "s/@SOURCE0@/$(TARBALL_BASENAME).tar.gz/g" \
+		-e "s/@NAME_VERSION@/$(TARBALL_BASENAME)/g" \
+		"$(SPEC_FILE).in" > "$(SPEC_FILE)"
+
+srpm: spec tarball
+	rm -rf "$(SRPM_OUTDIR)"/*.src.rpm
+	mkdir -p "$(SRPM_OUTDIR)/rpmbuild/SOURCES"
+	ln -sf "$${TARBALL_OUTDIR_ABS}/$${TARBALL_BASENAME}.tar.gz" "$(SRPM_OUTDIR)/rpmbuild/SOURCES/$${TARBALL_BASENAME}.tar.gz"
+	rpmbuild -bs "$(SPEC_FILE)" --undefine "dist" --define "%_topdir $(SRPM_OUTDIR)/rpmbuild"
+	mv "$(SRPM_OUTDIR)"/rpmbuild/SRPMS/*.src.rpm "$(SRPM_OUTDIR)/"
+	rm -rf "$(SRPM_OUTDIR)/rpmbuild"
+
+rpm: srpm
+	mkdir -p "$(RPM_OUTDIR)"
+	mock -r "$(RPM_BUILDROOT)" --resultdir="$(RPM_OUTDIR)" --rebuild "$(SRPM_OUTDIR)/"*.src.rpm
+
+clean:
+	rm -rf "$(RPM_OUTDIR)" "$(SRPM_OUTDIR)" "$${TARBALL_OUTDIR_ABS}" "$(SPEC_FILE)"
+
+
+.PHONY: tarball spec srpm rpm clean

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.qm
 ./.vscode
 CMakeSettings.json
+/makespec/qv2ray.spec
 
 SourceTrail/
 

--- a/makespec/qv2ray.spec.in
+++ b/makespec/qv2ray.spec.in
@@ -1,0 +1,56 @@
+%if 0%{?rhel}
+%global use_system_grpc 0
+%else
+%global use_system_grpc 1
+%endif
+
+Name:           @NAME@
+Version:        @VERSION@
+Release:        @RELEASE@
+Summary:        A Qt frontend for V2Ray, written in c++.
+
+License:        GPLv3
+URL:            https://github.com/Qv2ray/Qv2ray
+Source0:        @SOURCE0@
+
+BuildRequires:  cmake
+BuildRequires:  gcc-c++
+BuildRequires:  qt5-qtbase-devel
+BuildRequires:  qt5-qttools-devel
+BuildRequires:  protobuf-compiler
+BuildRequires:  protobuf-devel
+
+%if 0%{?use_system_grpc}
+BuildRequires:  grpc-devel
+BuildRequires:  grpc-plugins
+%endif
+
+%description
+A Qt based cross-platform GUI fontend for V2Ray.
+
+%prep
+%setup -q -n @NAME_VERSION@
+
+
+%build
+%cmake -DCMAKE_BUILD_TYPE:STRING=Release -DUSE_LIBQVB:BOOL=OFF -DEMBED_TRANSLATIONS:BOOL=ON .
+%make_build
+
+
+%install
+rm -rf "$RPM_BUILD_ROOT"
+%make_install
+install -D LICENSE "$RPM_BUILD_ROOT"/%{_datadir}/licenses/qv2ray/LICENSE
+install -D README.md "$RPM_BUILD_ROOT"/%{_docdir}/qv2ray/README.md
+
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/qv2ray
+%{_datadir}/icons/*
+%{_datadir}/applications/*
+%{_datadir}/metainfo/*
+
+
+%changelog


### PR DESCRIPTION
Adds RPM packaging support on [Fedora Copr](https://copr.fedorainfracloud.org/).
Currently only tested with Fedora 30+.
Supporting for other distributions like RHEL/CentOS/Suse/OpenSuse requires some dependencies that are not in their official repos so it is not covered in this PR.

Build RPMs locally:

``` bash
dnf install -y git mock make
make -f .copr/Makefile srpm  # build source RPM
make -f .copr/Makefile rpm  # build binary RPM
```

This makefile uses [Mock](https://github.com/rpm-software-management/mock) to build RPMs in a chroot environment. To use a chroot differed from your build distribution, use `RPM_BUILDROOT=<chroot-name>` Makefile variable.

For example, build against Fedora 32 on a CentOS 8 machine:

```bash
make -f .copr/Makefile rpm RPM_BUILDROOT=fedora-32-$(uname -m)
```

Example build: https://copr.fedorainfracloud.org/coprs/yux/v2ray/build/1329864/