### PR TITLE
add dns intercept and route for tproxy 

### DIFF
--- a/src/base/models/QvSettingsObject.hpp
+++ b/src/base/models/QvSettingsObject.hpp
@@ -84,18 +84,19 @@ namespace Qv2ray::base::config
         bool tproxy_followRedirect;
         /*redirect or tproxy way, and tproxy need cap_net_admin*/
         QString tproxy_mode;
+        bool dnsIntercept;
 
         Qv2rayInboundsConfig()
             : listenip("127.0.0.1"), setSystemProxy(true), useSocks(true), socks_port(1088), socks_useAuth(false), socksUDP(true),
               socksLocalIP("127.0.0.1"), socksAccount(), useHTTP(true), http_port(8888), http_useAuth(false), httpAccount(), useTPROXY(false),
               tproxy_ip("127.0.0.1"), tproxy_port(12345), tproxy_use_tcp(true), tproxy_use_udp(false), tproxy_followRedirect(true),
-              tproxy_mode("tproxy")
+              tproxy_mode("tproxy"),dnsIntercept(true)
         {
         }
 
         XTOSTRUCT(O(setSystemProxy, listenip, useSocks, useHTTP, socks_port, socks_useAuth, socksAccount, socksUDP, socksLocalIP, http_port,
                     http_useAuth, httpAccount, useTPROXY, tproxy_ip, tproxy_port, tproxy_use_tcp, tproxy_use_udp, tproxy_followRedirect,
-                    tproxy_mode))
+                    tproxy_mode,dnsIntercept))
     };
 
     struct Qv2rayOutboundsConfig

--- a/src/base/models/QvSettingsObject.hpp
+++ b/src/base/models/QvSettingsObject.hpp
@@ -90,13 +90,13 @@ namespace Qv2ray::base::config
             : listenip("127.0.0.1"), setSystemProxy(true), useSocks(true), socks_port(1088), socks_useAuth(false), socksUDP(true),
               socksLocalIP("127.0.0.1"), socksAccount(), useHTTP(true), http_port(8888), http_useAuth(false), httpAccount(), useTPROXY(false),
               tproxy_ip("127.0.0.1"), tproxy_port(12345), tproxy_use_tcp(true), tproxy_use_udp(false), tproxy_followRedirect(true),
-              tproxy_mode("tproxy"),dnsIntercept(true)
+              tproxy_mode("tproxy"), dnsIntercept(true)
         {
         }
 
         XTOSTRUCT(O(setSystemProxy, listenip, useSocks, useHTTP, socks_port, socks_useAuth, socksAccount, socksUDP, socksLocalIP, http_port,
                     http_useAuth, httpAccount, useTPROXY, tproxy_ip, tproxy_port, tproxy_use_tcp, tproxy_use_udp, tproxy_followRedirect,
-                    tproxy_mode,dnsIntercept))
+                    tproxy_mode, dnsIntercept))
     };
 
     struct Qv2rayOutboundsConfig

--- a/src/core/connection/Generation.cpp
+++ b/src/core/connection/Generation.cpp
@@ -515,6 +515,9 @@ namespace Qv2ray::core::connection
                 {
                     OutboundMarkSettingFilter(GlobalConfig.outboundConfig.mark, root);
                 }
+                if (GlobalConfig.inboundConfig.useTPROXY && GlobalConfig.inboundConfig.dnsIntercept){
+                    DNSInterceptFilter(root);
+                }
             }
 
             // Let's process some api features.
@@ -598,6 +601,23 @@ namespace Qv2ray::core::connection
             }
             root["outbounds"] = outbounds;
         }
+
+        void DNSInterceptFilter(CONFIGROOT &root){
+            // dns outBound
+            QJsonObject dnsOutboundObj{{"protocol","dns"},{"tag","dns-out"}};
+            OUTBOUNDS outbounds(root["outbounds"].toArray());
+            outbounds.append(dnsOutboundObj);
+            root["outbounds"] = outbounds;
+
+            //dns route
+            QJsonObject dnsRoutingRuleObj{{"outboundTag", "dns-out"},{"port","53"},{"type", "field"}};
+            ROUTING routing(root["routing"].toObject());
+            QJsonArray _rules(routing["rules"].toArray());
+            _rules.insert(0,dnsRoutingRuleObj);
+            routing["rules"]=_rules;
+            root["routing"]=routing;
+        }
+
 
     } // namespace Generation
 } // namespace Qv2ray::core::connection

--- a/src/core/connection/Generation.cpp
+++ b/src/core/connection/Generation.cpp
@@ -515,7 +515,8 @@ namespace Qv2ray::core::connection
                 {
                     OutboundMarkSettingFilter(GlobalConfig.outboundConfig.mark, root);
                 }
-                if (GlobalConfig.inboundConfig.useTPROXY && GlobalConfig.inboundConfig.dnsIntercept){
+                if (GlobalConfig.inboundConfig.useTPROXY && GlobalConfig.inboundConfig.dnsIntercept)
+                {
                     DNSInterceptFilter(root);
                 }
             }
@@ -602,22 +603,22 @@ namespace Qv2ray::core::connection
             root["outbounds"] = outbounds;
         }
 
-        void DNSInterceptFilter(CONFIGROOT &root){
+        void DNSInterceptFilter(CONFIGROOT &root)
+        {
             // dns outBound
-            QJsonObject dnsOutboundObj{{"protocol","dns"},{"tag","dns-out"}};
+            QJsonObject dnsOutboundObj{ { "protocol", "dns" }, { "tag", "dns-out" } };
             OUTBOUNDS outbounds(root["outbounds"].toArray());
             outbounds.append(dnsOutboundObj);
             root["outbounds"] = outbounds;
 
-            //dns route
-            QJsonObject dnsRoutingRuleObj{{"outboundTag", "dns-out"},{"port","53"},{"type", "field"}};
+            // dns route
+            QJsonObject dnsRoutingRuleObj{ { "outboundTag", "dns-out" }, { "port", "53" }, { "type", "field" } };
             ROUTING routing(root["routing"].toObject());
             QJsonArray _rules(routing["rules"].toArray());
-            _rules.insert(0,dnsRoutingRuleObj);
-            routing["rules"]=_rules;
-            root["routing"]=routing;
+            _rules.insert(0, dnsRoutingRuleObj);
+            routing["rules"] = _rules;
+            root["routing"] = routing;
         }
-
 
     } // namespace Generation
 } // namespace Qv2ray::core::connection

--- a/src/core/connection/Generation.hpp
+++ b/src/core/connection/Generation.hpp
@@ -40,6 +40,8 @@ namespace Qv2ray::core::connection
         // mark all outbound
         void OutboundMarkSettingFilter(const int mark, CONFIGROOT &root);
 
+        void DNSInterceptFilter(CONFIGROOT &root);
+
     } // namespace Generation
 } // namespace Qv2ray::core::connection
 

--- a/src/ui/w_PreferencesWindow.cpp
+++ b/src/ui/w_PreferencesWindow.cpp
@@ -1261,13 +1261,11 @@ void PreferencesWindow::on_jumpListCountSB_valueChanged(int arg1)
 void PreferencesWindow::on_outboundMark_valueChanged(int arg1)
 {
     NEEDRESTART
-    CurrentConfig.outboundConfig.mark=arg1;
+    CurrentConfig.outboundConfig.mark = arg1;
 }
-
 
 void PreferencesWindow::on_dnsIntercept_toggled(bool checked)
 {
     NEEDRESTART
-    CurrentConfig.inboundConfig.dnsIntercept=checked;
-
+    CurrentConfig.inboundConfig.dnsIntercept = checked;
 }

--- a/src/ui/w_PreferencesWindow.cpp
+++ b/src/ui/w_PreferencesWindow.cpp
@@ -128,6 +128,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QDialog(parent), Current
     tproxyFollowRedirect->setChecked(CurrentConfig.inboundConfig.tproxy_followRedirect);
     tproxyMode->setCurrentText(CurrentConfig.inboundConfig.tproxy_mode);
     outboundMark->setValue(CurrentConfig.outboundConfig.mark);
+    dnsIntercept->setChecked(CurrentConfig.inboundConfig.dnsIntercept);
     //
     //
     vCorePathTxt->setText(CurrentConfig.kernelConfig.KernelPath());
@@ -1261,4 +1262,12 @@ void PreferencesWindow::on_outboundMark_valueChanged(int arg1)
 {
     NEEDRESTART
     CurrentConfig.outboundConfig.mark=arg1;
+}
+
+
+void PreferencesWindow::on_dnsIntercept_toggled(bool checked)
+{
+    NEEDRESTART
+    CurrentConfig.inboundConfig.dnsIntercept=checked;
+
 }

--- a/src/ui/w_PreferencesWindow.hpp
+++ b/src/ui/w_PreferencesWindow.hpp
@@ -198,7 +198,7 @@ class PreferencesWindow
 
     void on_dnsIntercept_toggled(bool checked);
 
-private:
+  private:
     //
     RouteSettingsMatrixWidget *routeSettingsWidget;
     void SetAutoStartButtonsState(bool isAutoStart);

--- a/src/ui/w_PreferencesWindow.hpp
+++ b/src/ui/w_PreferencesWindow.hpp
@@ -196,7 +196,9 @@ class PreferencesWindow
 
     void on_outboundMark_valueChanged(int arg1);
 
-  private:
+    void on_dnsIntercept_toggled(bool checked);
+
+private:
     //
     RouteSettingsMatrixWidget *routeSettingsWidget;
     void SetAutoStartButtonsState(bool isAutoStart);

--- a/src/ui/w_PreferencesWindow.ui
+++ b/src/ui/w_PreferencesWindow.ui
@@ -705,8 +705,8 @@ Custom DNS Settings</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>710</width>
-            <height>520</height>
+            <width>703</width>
+            <height>524</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -1010,6 +1010,13 @@ Custom DNS Settings</string>
                    <widget class="QCheckBox" name="tproxyFollowRedirect">
                     <property name="text">
                      <string>Follow Redirect</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="dnsIntercept">
+                    <property name="text">
+                     <string>DNS Intercept</string>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
socks and http proxy can use v2ray inner dns resolver, while tproxy can not.
Intercept and route dns request to  dns outbund, then inner dns resolver handle this.
With this and doh, dns posion can be avoid.