### PR TITLE
After using flatwhite/psblack, switch back to breeze, bgcolor can't restored to original color

### DIFF
--- a/src/ui/styles/StyleManager.cpp
+++ b/src/ui/styles/StyleManager.cpp
@@ -59,8 +59,6 @@ namespace Qv2ray::ui::styles
                 qApp->processEvents();
                 //
                 const auto content = StringFromFile(s.qssPath);
-                QString paletteColor = content.mid(20, 7);
-                qApp->setPalette(QPalette(QColor(paletteColor)));
                 qApp->setStyleSheet(content);
                 return true;
             }


### PR DESCRIPTION
DE: KDE Plasma.
emmmm, maybe this is a feature?
current version: 2.6.0-rc2:5499