### PR TITLE
handle plural using Qt mechanism

### DIFF
--- a/src/core/handler/ConfigHandler.cpp
+++ b/src/core/handler/ConfigHandler.cpp
@@ -524,11 +524,10 @@ namespace Qv2ray::core::handler
         auto _newConnections = GetConnectionConfigFromSubscription(data, GetDisplayName(id));
         if (_newConnections.count() < 5)
         {
-            LOG(MODULE_SUBSCRIPTION, "Find a subscription with less than 5 connections.")
-            if (QvMessageBoxAsk(
-                    nullptr, tr("Update Subscription"),
-                    tr("%1 entrie(s) have been found from the subscription source, do you want to continue?").arg(_newConnections.count())) !=
-                QMessageBox::Yes)
+            LOG(MODULE_SUBSCRIPTION, "Found a subscription with less than 5 connections.")
+            if (QvMessageBoxAsk(nullptr, tr("Update Subscription"),
+                                tr("%n entrie(s) have been found from the subscription source, do you want to continue?", "",
+                                   _newConnections.count())) != QMessageBox::Yes)
 
                 return false;
         }
@@ -615,10 +614,10 @@ namespace Qv2ray::core::handler
 
         LOG(MODULE_SUBSCRIPTION, "Filtered out less than 5 connections.")
         const auto useFilteredConnections =
-            filteredConnections.count() > 5 || QvMessageBoxAsk(nullptr, tr("Update Subscription"),
-                                                               tr("%1 out of %2 entrie(s) have been filtered out, do you want to continue?")
-                                                                   .arg(filteredConnections.count())
-                                                                   .arg(_newConnections.count())) == QMessageBox::Yes;
+            filteredConnections.count() > 5 ||
+            QvMessageBoxAsk(nullptr, tr("Update Subscription"),
+                            tr("%1 out of %n entrie(s) have been filtered out, do you want to continue?", "", _newConnections.count())
+                                .arg(filteredConnections.count())) == QMessageBox::Yes;
 
         for (const auto &config : useFilteredConnections ? filteredConnections : _newConnections)
         {

--- a/src/ui/widgets/ConnectionInfoWidget.cpp
+++ b/src/ui/widgets/ConnectionInfoWidget.cpp
@@ -107,7 +107,7 @@ void ConnectionInfoWidget::ShowDetails(const ConnectionGroupPair &_identifier)
         complexCount += shareLinks.removeAll("");
         if (complexCount > 0)
         {
-            shareLinks << "# " + tr("(Ignored %1 complex config(s))").arg(complexCount);
+            shareLinks << "# " + tr("(Ignored %n complex config(s))", "", complexCount);
         }
         //
         groupShareTxt->setPlainText(shareLinks.join(NEWLINE));

--- a/src/ui/windows/w_MainWindow.cpp
+++ b/src/ui/windows/w_MainWindow.cpp
@@ -584,7 +584,9 @@ void MainWindow::on_action_RCM_DeleteThese_triggered()
         return;
     }
 
-    if (QvMessageBoxAsk(this, tr("Removing Connection(s)"), tr("Are you sure to remove selected connection(s)?")) != QMessageBox::Yes)
+    const auto strRemoveConnTitle = tr("Removing Connection(s)", "", connlist.count());
+    const auto strRemoveConnContent = tr("Are you sure to remove selected connection(s)?", "", connlist.count());
+    if (QvMessageBoxAsk(this, strRemoveConnTitle, strRemoveConnContent) != QMessageBox::Yes)
     {
         return;
     }
@@ -913,8 +915,9 @@ void MainWindow::on_action_RCM_DuplicateThese_triggered()
 
     LOG(MODULE_UI, "Selected " + QSTRN(connlist.count()) + " items")
 
-    if (connlist.count() > 1 && QvMessageBoxAsk(this, tr("Duplicating Connection(s)"), //
-                                                tr("Are you sure to duplicate these connection(s)?")) != QMessageBox::Yes)
+    const auto strDupConnTitle = tr("Duplicating Connection(s)", "", connlist.count());
+    const auto strDupConnContent = tr("Are you sure to duplicate these connection(s)?", "", connlist.count());
+    if (connlist.count() > 1 && QvMessageBoxAsk(this, strDupConnTitle, strDupConnContent) != QMessageBox::Yes)
     {
         return;
     }

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -68,10 +68,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(Ignored %1 complex config(s))</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Not a subscription</source>
         <translation type="unfinished"></translation>
     </message>
@@ -82,6 +78,13 @@
     <message>
         <source>Are you sure to delete the current item?</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>(Ignored %n complex config(s))</source>
+        <translation>
+            <numerusform>(Ignored %n complex config)</numerusform>
+            <numerusform>(Ignored %n complex configs)</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -648,18 +651,6 @@
         <source>tproxy mode</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>redirect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tproxy</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>InboundSettingsWidget</name>
@@ -947,13 +938,19 @@
         <source>Are you sure to exit Qv2ray?</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Removing Connection(s)</source>
-        <translation type="unfinished"></translation>
+        <translation>
+            <numerusform>Removing Connection</numerusform>
+            <numerusform>Removing Connections</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Are you sure to remove selected connection(s)?</source>
-        <translation type="unfinished"></translation>
+        <translation>
+            <numerusform>Are you sure to remove selected connection?</numerusform>
+            <numerusform>Are you sure to remove selected connections?</numerusform>
+        </translation>
     </message>
     <message>
         <source>Disconnected from: </source>
@@ -963,13 +960,19 @@
         <source>Connected: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Duplicating Connection(s)</source>
-        <translation type="unfinished"></translation>
+        <translation>
+            <numerusform>Duplicating Connection</numerusform>
+            <numerusform>Duplicating Connections</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Are you sure to duplicate these connection(s)?</source>
-        <translation type="unfinished"></translation>
+        <translation>
+            <numerusform>Are you sure to duplicate this connection?</numerusform>
+            <numerusform>Are you sure to duplicate these connections?</numerusform>
+        </translation>
     </message>
     <message>
         <source> (Copy)</source>
@@ -1333,11 +1336,6 @@ This could resolve the certificate issues, but also could let one performing TLS
     <message>
         <source>Run TCPing or ICMPing periodcally after connecting to a server.
 Qv2ray will give a more accurate latency value if Enabled, but makes it easy to fingerprint the connection.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>These settings may be useful.
-But could dramatically damage your server if improperly used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1833,6 +1831,11 @@ Custom DNS Settings</source>
         <source>Invalid DNS settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>These settings may be useful.
+But could damage your server if improperly used.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
@@ -2292,6 +2295,10 @@ Custom DNS Settings</source>
         <source>Port: %1 for listening IP: %2 for inbound tag: &quot;%3&quot;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Port: %1 for listening IP: 127.0.0.1 for plugin integration.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Qv2ray::core::handler::QvConfigHandler</name>
@@ -2312,16 +2319,22 @@ Custom DNS Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 entrie(s) have been found from the subscription source, do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 out of %2 entrie(s) have been filtered out, do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Group: %1</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n entrie(s) have been found from the subscription source, do you want to continue?</source>
+        <translation>
+            <numerusform>%n entry has been found from the subscription source, do you want to continue?</numerusform>
+            <numerusform>%n entries have been found from the subscription source, do you want to continue?</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 out of %n entrie(s) have been filtered out, do you want to continue?</source>
+        <translation>
+            <numerusform>%1 out of %n entry have been filtered out, do you want to continue?</numerusform>
+            <numerusform>%1 out of %n entries have been filtered out, do you want to continue?</numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/ja_JP.ts
+++ b/translations/ja_JP.ts
@@ -68,10 +68,6 @@
         <translation>リンクを共有</translation>
     </message>
     <message>
-        <source>(Ignored %1 complex config(s))</source>
-        <translation>（%1の複雑構成は無視されました）</translation>
-    </message>
-    <message>
         <source>Not a subscription</source>
         <translation>サブスクリプションではありません</translation>
     </message>
@@ -82,6 +78,12 @@
     <message>
         <source>Are you sure to delete the current item?</source>
         <translation>現在のアイテムを削除してもよろしいですか？</translation>
+    </message>
+    <message numerus="yes">
+        <source>(Ignored %n complex config(s))</source>
+        <translation>
+            <numerusform>(無視される %n 複雑な構成)</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -648,18 +650,6 @@
         <source>tproxy mode</source>
         <translation>透過プロキシのモード</translation>
     </message>
-    <message>
-        <source>off</source>
-        <translation>オフ</translation>
-    </message>
-    <message>
-        <source>redirect</source>
-        <translation>リダイレクト</translation>
-    </message>
-    <message>
-        <source>tproxy</source>
-        <translation>tproxy</translation>
-    </message>
 </context>
 <context>
     <name>InboundSettingsWidget</name>
@@ -921,13 +911,17 @@
         <source>Are you sure to exit Qv2ray?</source>
         <translation>Qv2rayを終了してよろしいでしょうか？</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Duplicating Connection(s)</source>
-        <translation>項目をコピー</translation>
+        <translation>
+            <numerusform>項目をコピー</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Are you sure to duplicate these connection(s)?</source>
-        <translation>選択した項目をコピーしますか？</translation>
+        <translation>
+            <numerusform>選択した項目をコピーしますか？</numerusform>
+        </translation>
     </message>
     <message>
         <source> (Copy)</source>
@@ -969,13 +963,17 @@
         <source>Disconnected from: </source>
         <translation>接続切断されました: </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Removing Connection(s)</source>
-        <translation>項目を削除</translation>
+        <translation>
+            <numerusform>項目を削除</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Are you sure to remove selected connection(s)?</source>
-        <translation>選択した項目を削除しますか？</translation>
+        <translation>
+            <numerusform>選択した項目を削除しますか？</numerusform>
+        </translation>
     </message>
     <message>
         <source>Plugins</source>
@@ -1464,7 +1462,7 @@
     </message>
     <message>
         <source>This will make your TLS fingerpring different from common golang programs.</source>
-        <translation type="unfinished"></translation>
+        <translation>これにより、TLS の指紋は一般的な Golang プログラムとは異なるものになります。</translation>
     </message>
     <message>
         <source>This will (probably) make it easy to fingerprint your connection.</source>
@@ -1787,12 +1785,6 @@ For example, for updating subscriptions.</source>
         <translation>デフォルトで AllowInsecure を設定する</translation>
     </message>
     <message>
-        <source>These settings may be useful.
-But could dramatically damage your server if improperly used.</source>
-        <translation>以下の設定は特定の効果があります。
-しかし、不適切な使用の場合、不都合が生じる可能性があります。</translation>
-    </message>
-    <message>
         <source>Enable SessionResumption By Default</source>
         <translation>デフォルトで SessionResumption を有効にする</translation>
     </message>
@@ -1843,6 +1835,12 @@ But could dramatically damage your server if improperly used.</source>
     <message>
         <source>Invalid DNS settings.</source>
         <translation>DNSの設定が無効です。</translation>
+    </message>
+    <message>
+        <source>These settings may be useful.
+But could damage your server if improperly used.</source>
+        <translation>これらの設定は役に立つかもしれません。
+しかし、不適切な使い方をするとサーバーにダメージを与える可能性があります。</translation>
     </message>
 </context>
 <context>
@@ -2303,6 +2301,10 @@ But could dramatically damage your server if improperly used.</source>
         <source>Port: %1 for listening IP: %2 for inbound tag: &quot;%3&quot;</source>
         <translation>受信タグ &quot;%1&quot; は、ポート &quot;%3&quot; で &quot;%2&quot; をリッスンする必要があります</translation>
     </message>
+    <message>
+        <source>Port: %1 for listening IP: 127.0.0.1 for plugin integration.</source>
+        <translation>プラグイン統合は、ポート &quot;%1&quot; で 127.0.0.1 をリッスンする必要があります。</translation>
+    </message>
 </context>
 <context>
     <name>Qv2ray::core::handler::QvConfigHandler</name>
@@ -2323,16 +2325,20 @@ But could dramatically damage your server if improperly used.</source>
         <translation>サブスクリプションを更新</translation>
     </message>
     <message>
-        <source>%1 entrie(s) have been found from the subscription source, do you want to continue?</source>
-        <translation>アップストリームから返されるノードは %1 つだけです。続行してもよろしいですか？</translation>
-    </message>
-    <message>
-        <source>%1 out of %2 entrie(s) have been filtered out, do you want to continue?</source>
-        <translation>%2 つのエントリのうち %1 がフィルタリングされましたが、続行しますか?</translation>
-    </message>
-    <message>
         <source>Group: %1</source>
         <translation>グループ: %1</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n entrie(s) have been found from the subscription source, do you want to continue?</source>
+        <translation>
+            <numerusform>サブスクリプションソースから %n 項目が見つかりましたが、続けますか?</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 out of %n entrie(s) have been filtered out, do you want to continue?</source>
+        <translation>
+            <numerusform>%n 個のエントリのうち %1 個がフィルタリングされましたが、続けますか？</numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished">Поделитесь ссылкой</translation>
     </message>
     <message>
-        <source>(Ignored %1 complex config(s))</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Not a subscription</source>
         <translation type="unfinished"></translation>
     </message>
@@ -82,6 +78,14 @@
     <message>
         <source>Group Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>(Ignored %n complex config(s))</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -648,18 +652,6 @@
         <source>tproxy mode</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>redirect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tproxy</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>InboundSettingsWidget</name>
@@ -877,13 +869,21 @@
         <source>Are you sure to exit Qv2ray?</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Duplicating Connection(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Are you sure to duplicate these connection(s)?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source> (Copy)</source>
@@ -925,13 +925,21 @@
         <source>Disconnected from: </source>
         <translation>Отключен от:</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Removing Connection(s)</source>
-        <translation>Удаление подключения(й)</translation>
+        <translation type="unfinished">
+            <numerusform>Удаление подключения(й)</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Are you sure to remove selected connection(s)?</source>
-        <translation>Вы уверены, что хотите удалить выбранные подключение(и)?</translation>
+        <translation type="unfinished">
+            <numerusform>Вы уверены, что хотите удалить выбранные подключение(и)?</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Plugins</source>
@@ -1779,11 +1787,6 @@ For example, for updating subscriptions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>These settings may be useful.
-But could dramatically damage your server if improperly used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Enable SessionResumption By Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1833,6 +1836,11 @@ But could dramatically damage your server if improperly used.</source>
     </message>
     <message>
         <source>Invalid DNS settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>These settings may be useful.
+But could damage your server if improperly used.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2294,6 +2302,10 @@ But could dramatically damage your server if improperly used.</source>
         <source>Port: %1 for listening IP: %2 for inbound tag: &quot;%3&quot;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Port: %1 for listening IP: 127.0.0.1 for plugin integration.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Qv2ray::core::handler::QvConfigHandler</name>
@@ -2314,16 +2326,24 @@ But could dramatically damage your server if improperly used.</source>
         <translation type="unfinished">Обновить подписку</translation>
     </message>
     <message>
-        <source>%1 entrie(s) have been found from the subscription source, do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 out of %2 entrie(s) have been filtered out, do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Group: %1</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n entrie(s) have been found from the subscription source, do you want to continue?</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 out of %n entrie(s) have been filtered out, do you want to continue?</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -68,10 +68,6 @@
         <translation>分享链接</translation>
     </message>
     <message>
-        <source>(Ignored %1 complex config(s))</source>
-        <translation>(已忽略 %1 个复杂配置)</translation>
-    </message>
-    <message>
         <source>Not a subscription</source>
         <translation>不是订阅</translation>
     </message>
@@ -82,6 +78,12 @@
     <message>
         <source>Are you sure to delete the current item?</source>
         <translation>您确定要删除当前项目吗？</translation>
+    </message>
+    <message numerus="yes">
+        <source>(Ignored %n complex config(s))</source>
+        <translation>
+            <numerusform>（忽略 %n 个复杂配置）</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -648,18 +650,6 @@
         <source>tproxy mode</source>
         <translation>透明代理模式</translation>
     </message>
-    <message>
-        <source>off</source>
-        <translation>关闭</translation>
-    </message>
-    <message>
-        <source>redirect</source>
-        <translation>重定向</translation>
-    </message>
-    <message>
-        <source>tproxy</source>
-        <translation>tproxy</translation>
-    </message>
 </context>
 <context>
     <name>InboundSettingsWidget</name>
@@ -825,13 +815,17 @@
         <source>Connected: </source>
         <translation>已连接: </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Duplicating Connection(s)</source>
-        <translation>复制连接</translation>
+        <translation>
+            <numerusform>复制连接</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Are you sure to duplicate these connection(s)?</source>
-        <translation>您确定要复制这（些）连接吗？</translation>
+        <translation>
+            <numerusform>您确定要复制这（些）连接吗？</numerusform>
+        </translation>
     </message>
     <message>
         <source> (Copy)</source>
@@ -865,9 +859,11 @@
         <source>Disconnected from: </source>
         <translation>已断开连接: </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Removing Connection(s)</source>
-        <translation>删除连接</translation>
+        <translation>
+            <numerusform>删除连接</numerusform>
+        </translation>
     </message>
     <message>
         <source>Kernel terminated.</source>
@@ -889,9 +885,11 @@
         <source>Are you sure to exit Qv2ray?</source>
         <translation>确信要退出 Qv2ray 吗？</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>Are you sure to remove selected connection(s)?</source>
-        <translation>您确定要删除这（些）连接吗？</translation>
+        <translation>
+            <numerusform>您确定要删除这些项目吗？</numerusform>
+        </translation>
     </message>
     <message>
         <source>Locate Current Connection</source>
@@ -1443,10 +1441,6 @@
         <translation>你会失去 TLS 的保护，并可能使您的连接受害于中间人攻击（MitM）。</translation>
     </message>
     <message>
-        <source>这将使你的 TLS 指纹与常见的 golang 程序不同。</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This will (probably) make it easy to fingerprint your connection.</source>
         <translation>这将让 GFW 更容易识别出您的连接。</translation>
     </message>
@@ -1787,12 +1781,6 @@ For example, for updating subscriptions.</source>
         <translation>默认设置 AllowInsecure</translation>
     </message>
     <message>
-        <source>These settings may be useful.
-But could dramatically damage your server if improperly used.</source>
-        <translation>以下设定可能很有用。
-但若使用不当，可能会造成负面影响。</translation>
-    </message>
-    <message>
         <source>Enable SessionResumption By Default</source>
         <translation>默认允许 SessionResumption</translation>
     </message>
@@ -1843,6 +1831,16 @@ But could dramatically damage your server if improperly used.</source>
     <message>
         <source>Invalid DNS settings.</source>
         <translation>无效的 DNS 设置。</translation>
+    </message>
+    <message>
+        <source>These settings may be useful.
+But could damage your server if improperly used.</source>
+        <translation>此处的设定可能很有用。
+但若使用不当，将会造成不良后果。</translation>
+    </message>
+    <message>
+        <source>This will make your TLS fingerpring different from common golang programs.</source>
+        <translation>这将让你的 TLS 指纹有异于正常的 Golang 程序。</translation>
     </message>
 </context>
 <context>
@@ -2303,6 +2301,10 @@ But could dramatically damage your server if improperly used.</source>
         <source>Port: %1 for listening IP: %2 for inbound tag: &quot;%3&quot;</source>
         <translation>入站标签 &quot;%3&quot; 需要在 %2 监听端口 %1</translation>
     </message>
+    <message>
+        <source>Port: %1 for listening IP: 127.0.0.1 for plugin integration.</source>
+        <translation>插件集成需要在 127.0.0.1 的 %1 端口监听。</translation>
+    </message>
 </context>
 <context>
     <name>Qv2ray::core::handler::QvConfigHandler</name>
@@ -2323,16 +2325,20 @@ But could dramatically damage your server if improperly used.</source>
         <translation>更新订阅</translation>
     </message>
     <message>
-        <source>%1 entrie(s) have been found from the subscription source, do you want to continue?</source>
-        <translation>订阅源仅返回了 %1 个节点，确定要继续吗？</translation>
-    </message>
-    <message>
-        <source>%1 out of %2 entrie(s) have been filtered out, do you want to continue?</source>
-        <translation>%2 条连接中仅有 %1 条可用，确定要继续吗？</translation>
-    </message>
-    <message>
         <source>Group: %1</source>
         <translation>分组: %1</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n entrie(s) have been found from the subscription source, do you want to continue?</source>
+        <translation>
+            <numerusform>订阅中仅有 %n 项可用，要继续吗？</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 out of %n entrie(s) have been filtered out, do you want to continue?</source>
+        <translation>
+            <numerusform>%n 条中过滤出 %1 条项目，要继续吗？</numerusform>
+        </translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
终于理解为啥 Qt 要把 en_US 翻译成 en_US 了。原来还有一个复数的问题。
@Qv2ray-dev plz review.