### PR TITLE
DnsWidget: handle port in DoH cases

### DIFF
--- a/src/ui/widgets/DnsSettingsWidget.cpp
+++ b/src/ui/widgets/DnsSettingsWidget.cpp
@@ -20,6 +20,7 @@ using Qv2ray::common::validation::IsValidIPAddress;
     detailsSettingsGB->setEnabled(serversListbox->count() > 0);                                                                                 \
     serverAddressTxt->setEnabled(serversListbox->count() > 0);                                                                                  \
     removeServerBtn->setEnabled(serversListbox->count() > 0);                                                                                   \
+    ProcessDnsPortEnabledState();                                                                                                               \
     CHECK_DISABLE_MOVE_BTN
 
 #define currentServerIndex serversListbox->currentRow()
@@ -97,6 +98,18 @@ bool DnsSettingsWidget::CheckIsValidDNS() const
     return true;
 }
 
+void DnsSettingsWidget::ProcessDnsPortEnabledState()
+{
+    if (const auto addr = serverAddressTxt->text(); addr.startsWith("https:") || addr.startsWith("https+"))
+    {
+        serverPortSB->setEnabled(false);
+    }
+    else
+    {
+        serverPortSB->setEnabled(true);
+    }
+}
+
 void DnsSettingsWidget::ShowCurrentDnsServerDetails()
 {
     serverAddressTxt->setText(dns.servers[currentServerIndex].address);
@@ -115,6 +128,7 @@ void DnsSettingsWidget::ShowCurrentDnsServerDetails()
     {
         RED(serverAddressTxt)
     }
+    ProcessDnsPortEnabledState();
 }
 
 DNSObject DnsSettingsWidget::GetDNSObject()
@@ -223,6 +237,8 @@ void DnsSettingsWidget::on_serverAddressTxt_textEdited(const QString &arg1)
     {
         RED(serverAddressTxt)
     }
+
+    ProcessDnsPortEnabledState();
 }
 
 void DnsSettingsWidget::on_serverPortSB_valueChanged(int arg1)

--- a/src/ui/widgets/DnsSettingsWidget.hpp
+++ b/src/ui/widgets/DnsSettingsWidget.hpp
@@ -38,6 +38,7 @@ class DnsSettingsWidget
 
   private:
     void ShowCurrentDnsServerDetails();
+    void ProcessDnsPortEnabledState();
     QvMessageBusSlotDecl;
     DNSObject dns;
     // int currentServerIndex;

--- a/src/ui/widgets/DnsSettingsWidget.ui
+++ b/src/ui/widgets/DnsSettingsWidget.ui
@@ -24,7 +24,13 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="dnsClientIPTxt"/>
+      <widget class="QLineEdit" name="dnsClientIPTxt">
+       <property name="toolTip">
+        <string>The current system's IP address is used to notify the server of the client's location when querying DNS. 
+
+It cannot be a private address.</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QLabel" name="label_2">
@@ -34,7 +40,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="dnsTagTxt"/>
+      <widget class="QLineEdit" name="dnsTagTxt">
+       <property name="toolTip">
+        <string>(V2Ray 4.13+) The query traffic sent by this DNS, except for localhost and DOHL modes, will carry this identifier, which can be matched with inboundTag in the route.</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -188,6 +198,10 @@
                </item>
                <item>
                 <widget class="QSpinBox" name="serverPortSB">
+                 <property name="toolTip">
+                  <string>Port for DNS server. Normally it's 53.
+This entry is ignored by V2Ray core when using DoH servers.</string>
+                 </property>
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::NoButtons</enum>
                  </property>


### PR DESCRIPTION
port is ignored when using DoH, therefore some extra hints might be needed.