### PR TITLE
under custom theme, the screenshot is solid color

### DIFF
--- a/src/ui/windows/w_ScreenShot_Core.cpp
+++ b/src/ui/windows/w_ScreenShot_Core.cpp
@@ -156,6 +156,10 @@ void ScreenShotWindow::mouseReleaseEvent(QMouseEvent *e)
     {
         reject();
     }
+    else if (e->button() == Qt::LeftButton)
+    {
+        rubber.hide();
+    }
 }
 
 ScreenShotWindow::~ScreenShotWindow()

--- a/src/ui/windows/w_ScreenShot_Core.cpp
+++ b/src/ui/windows/w_ScreenShot_Core.cpp
@@ -57,7 +57,7 @@ QImage ScreenShotWindow::DoScreenShot()
             bg_grey.setPixel(i, j, qRgb(r, g, b));
         }
     }
-
+    setStyleSheet("QDialog { background-color: transparent; }");
     bg_grey = bg_grey.scaled(bg_grey.size() / devicePixelRatio(), Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation);
     auto p = this->palette();
     p.setBrush(QPalette::Window, bg_grey);


### PR DESCRIPTION
use flatwhite / psblack theme
mainwindow -> New -> QR Code -> Go
the second commit solves the problem that  the target area is light blue when screenshot cause by first commit
maybe the code on [L111~L112](https://github.com/Qv2ray/Qv2ray/blob/f1f94af88d174819f63edfc52a3ba624b5fc1879/src/ui/windows/w_ScreenShot_Core.cpp#L111-L112) is unnecessary?
