### PR TITLE
解决更新KDE后SESSION环境变量的问题

### DIFF
--- a/src/components/proxy/QvProxyConfigurator.cpp
+++ b/src/components/proxy/QvProxyConfigurator.cpp
@@ -233,7 +233,7 @@ namespace Qv2ray::components::proxy
         QList<ProcessArgument> actions;
         actions << ProcessArgument{ "gsettings", { "set", "org.gnome.system.proxy", "mode", "manual" } };
         //
-        bool isKDE = qEnvironmentVariable("XDG_SESSION_DESKTOP") == "KDE";
+        bool isKDE = qEnvironmentVariable("XDG_SESSION_DESKTOP") == "KDE" || qEnvironmentVariable("XDG_SESSION_DESKTOP") == "plasma";
         bool isDDE = !isKDE && qEnvironmentVariable("XDG_CURRENT_DESKTOP").toLower() == "deepin";
         const auto configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
 
@@ -403,7 +403,7 @@ namespace Qv2ray::components::proxy
         InternetSetOption(nullptr, INTERNET_OPTION_REFRESH, nullptr, 0);
 #elif defined(Q_OS_LINUX)
         QList<ProcessArgument> actions;
-        const bool isKDE = qEnvironmentVariable("XDG_SESSION_DESKTOP") == "KDE";
+        const bool isKDE = qEnvironmentVariable("XDG_SESSION_DESKTOP") == "KDE" || qEnvironmentVariable("XDG_SESSION_DESKTOP") == "plasma";
         const auto configRoot = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
 
         // Setting System Proxy Mode to: None


### PR DESCRIPTION
解决更新KDE后SESSION环境变量的问题

在提交[issues#864](https://github.com/Qv2ray/Qv2ray/issues/864)后，经查找发现是更新KDE的问题。

在新版本KDE中环境变量变为 DESKTOP_SESSION=plasma 遂更改。

为了兼容较旧的KDE 变为
```
bool isKDE = qEnvironmentVariable("XDG_SESSION_DESKTOP") == "KDE" || qEnvironmentVariable("XDG_SESSION_DESKTOP") == "plasma";
```