### PR TITLE
fix(compatibility): polyfill for Qt <= 5.14

### DIFF
--- a/src/ui/widgets/widgets/StreamSettingsWidget.cpp
+++ b/src/ui/widgets/widgets/StreamSettingsWidget.cpp
@@ -313,8 +313,13 @@ void StreamSettingsWidget::on_disableSessionResumptionCB_stateChanged(int arg1)
 
 void StreamSettingsWidget::on_alpnTxt_textEdited(const QString &arg1)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     stream.tlsSettings.alpn = arg1.split('|', Qt::SplitBehaviorFlags::SkipEmptyParts);
     stream.xtlsSettings.alpn = arg1.split('|', Qt::SplitBehaviorFlags::SkipEmptyParts);
+#else
+    stream.tlsSettings.alpn = arg1.split('|', QString::SkipEmptyParts);
+    stream.xtlsSettings.alpn = arg1.split('|', QString::SkipEmptyParts);
+#endif
 }
 
 void StreamSettingsWidget::on_disableSystemRoot_stateChanged(int arg1)


### PR DESCRIPTION
Qt::SplitBehaviorFlags::SkipEmptyParts => QString::SkipEmptyParts