### PR TITLE
SCHEDULED BREAKING CHANGE for Filename of Windows Installer Release

### DIFF
--- a/.github/workflows/nsis.yml
+++ b/.github/workflows/nsis.yml
@@ -114,6 +114,6 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: build/${{ steps.get_package.outputs.NAME }}
-          asset_name: ${{ steps.get_package.outputs.NAME }}
+          asset_name: Qv2ray.${{ steps.get_version.outputs.VERSION }}.Windows-${{ matrix.arch }}.exe
           tag: ${{ github.ref }}
           overwrite: true


### PR DESCRIPTION
## When
We will merge this breaking change before the release of Qv2ray v2.7.0 stable, which may take a few weeks, in Mid November, 2020.

## What
 - Before: 
    - `qv2ray-2.6.3-win32.exe`
    - `qv2ray-2.6.3-win64.exe`
 - After: `"Qv2ray.v${VERSION}.Windows-${ARCH}.exe"` where `ARCH ::= "x86" | "x64"` 
    - `Qv2ray.v2.6.3.Windows-x86.exe`
    - `Qv2ray.v2.6.3.Windows-x64.exe`

## Known Affected Sources
 - WinGet (@kidonng, @U-v-U and @VictorNanka)

## Scheduled Actions 
 - [x] @U-v-U: Completed Release of Qv2ray v2.7.0 stable version
 - [x] @DuckSoft: Send Modified Pull-Request to WinGet
 - [x] Await WinGet to merge the Pull-Request
 - [x] Done
