### PR TITLE
fix: fix github action warnings

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -23,7 +23,7 @@ jobs:
         id: get_message
         run: |
           echo "::set-output name=message::$(git log --format=%B -n 1 ${{ github.event.after }})"
-          echo "::set-env name=message::$(git log --format=%B -n 1 ${{ github.event.after }})"
+          echo "message=$(git log --format=%B -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
 
   aur:
     needs: check_commit_msg

--- a/.github/workflows/build-qv2ray-cmake.yml
+++ b/.github/workflows/build-qv2ray-cmake.yml
@@ -17,7 +17,7 @@ jobs:
         id: get_message
         run: |
           echo "::set-output name=message::$(git log --format=%B -n 1 ${{ github.event.after }})"
-          echo "::set-env name=message::$(git log --format=%B -n 1 ${{ github.event.after }})"
+          echo "message=$(git log --format=%B -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
   build:
     needs: check_commit_msg
     if: ${{ !contains( needs.check_commit_msg.outputs.commit_message, 'NO_MAIN') }}

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -17,7 +17,7 @@ jobs:
         id: get_message
         run: |
           echo "::set-output name=message::$(git log --format=%B -n 1 ${{ github.event.after }})"
-          echo "::set-env name=message::$(git log --format=%B -n 1 ${{ github.event.after }})"
+          echo "message=$(git log --format=%B -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
 
   build:
     strategy:

--- a/.github/workflows/hashfile.yml
+++ b/.github/workflows/hashfile.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - run: echo ::set-env name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      - run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_ENV
         shell: bash
-      - run: echo ::set-env name=REPOSITORY_NAME::$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}')
+      - run: echo REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}') >> $GITHUB_ENV
         shell: bash
       - name: Checking out sources
         uses: actions/checkout@v2

--- a/.github/workflows/nsis.yml
+++ b/.github/workflows/nsis.yml
@@ -17,7 +17,7 @@ jobs:
         id: get_message
         run: |
           echo "::set-output name=message::$(git log --format=%B -n 1 ${{ github.event.after }})"
-          echo "::set-env name=message::$(git log --format=%B -n 1 ${{ github.event.after }})"
+          echo "message=$(git log --format=%B -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
   build:
     needs: check_commit_msg
     if: ${{ !contains( needs.check_commit_msg.outputs.commit_message, 'NO_NSIS') }}

--- a/.github/workflows/pacman.yml
+++ b/.github/workflows/pacman.yml
@@ -17,7 +17,7 @@ jobs:
         id: get_message
         run: |
           echo "::set-output name=message::$(git log --format=%B -n 1 ${{ github.event.after }})"
-          echo "::set-env name=message::$(git log --format=%B -n 1 ${{ github.event.after }})"
+          echo "message=$(git log --format=%B -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
   linux:
     needs: check_commit_msg
     if: ${{ !contains( needs.check_commit_msg.outputs.commit_message, 'NO_PACMAN') }}


### PR DESCRIPTION
[https://github.com/Qv2ray/Qv2ray/runs/1394513049](https://github.com/Qv2ray/Qv2ray/runs/1394513049)
`add-path` 和 `set-env` 将在 11月16号停用。

相关阅读
[https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

[https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable)

这个PR只修改了 `set-env` 部分，`add-path` 由 [setup-ninja](https://github.com/ashutoshvarma/setup-ninja) 引起，而 setup-ninja 的 [PR](https://github.com/ashutoshvarma/setup-ninja/pull/3) 还未合并....