### PR TITLE
fix: Replace currentIndexChanged(const QString&) with currentTextChan…

### DIFF
--- a/src/plugins/protocols/ui/inbound/socksin.cpp
+++ b/src/plugins/protocols/ui/inbound/socksin.cpp
@@ -103,8 +103,8 @@ void SocksInboundEditor::on_socksUDPIPAddrTxt_textEdited(const QString &arg1)
     content["ip"] = arg1;
 }
 
-void SocksInboundEditor::on_socksAuthCombo_currentIndexChanged(const QString &arg1)
+void SocksInboundEditor::on_socksAuthCombo_currentIndexChanged(int arg1)
 {
     PLUGIN_EDITOR_LOADING_GUARD
-    content["auth"] = arg1.toLower();
+    content["auth"] = socksAuthCombo->itemText(arg1).toLower();
 }

--- a/src/plugins/protocols/ui/inbound/socksin.hpp
+++ b/src/plugins/protocols/ui/inbound/socksin.hpp
@@ -36,7 +36,7 @@ class SocksInboundEditor
 
     void on_socksAddUserBtn_clicked();
 
-    void on_socksAuthCombo_currentIndexChanged(const QString &arg1);
+    void on_socksAuthCombo_currentIndexChanged(int arg1);
 
   protected:
     void changeEvent(QEvent *e) override;

--- a/src/plugins/protocols/ui/outbound/vmess.cpp
+++ b/src/plugins/protocols/ui/outbound/vmess.cpp
@@ -34,11 +34,11 @@ void VmessOutboundEditor::on_idLineEdit_textEdited(const QString &arg1)
     vmess.users.front().id = arg1;
 }
 
-void VmessOutboundEditor::on_securityCombo_currentIndexChanged(const QString &arg1)
+void VmessOutboundEditor::on_securityCombo_currentIndexChanged(int arg1)
 {
     if (vmess.users.isEmpty())
         vmess.users << VMessServerObject::UserObject{};
-    vmess.users.front().security = arg1;
+    vmess.users.front().security = securityCombo->itemText(arg1);
 }
 
 void VmessOutboundEditor::on_alterLineEdit_valueChanged(int arg1)

--- a/src/plugins/protocols/ui/outbound/vmess.hpp
+++ b/src/plugins/protocols/ui/outbound/vmess.hpp
@@ -56,6 +56,6 @@ class VmessOutboundEditor
 
   private slots:
     void on_idLineEdit_textEdited(const QString &arg1);
-    void on_securityCombo_currentIndexChanged(const QString &arg1);
+    void on_securityCombo_currentIndexChanged(int arg1);
     void on_alterLineEdit_valueChanged(int arg1);
 };

--- a/src/ui/widgets/editors/w_InboundEditor.cpp
+++ b/src/ui/widgets/editors/w_InboundEditor.cpp
@@ -161,10 +161,10 @@ void InboundEditor::on_inboundTagTxt_textEdited(const QString &arg1)
     CHECKLOADING
     current["tag"] = arg1;
 }
-void InboundEditor::on_strategyCombo_currentIndexChanged(const QString &arg1)
+void InboundEditor::on_strategyCombo_currentIndexChanged(int arg1)
 {
     CHECKLOADING
-    allocateSettings["strategy"] = arg1.toLower();
+    allocateSettings["strategy"] = strategyCombo->itemText(arg1).toLower();
 }
 
 void InboundEditor::on_refreshNumberBox_valueChanged(int arg1)

--- a/src/ui/widgets/editors/w_InboundEditor.hpp
+++ b/src/ui/widgets/editors/w_InboundEditor.hpp
@@ -28,7 +28,7 @@ class InboundEditor
 
     void on_inboundTagTxt_textEdited(const QString &arg1);
 
-    void on_strategyCombo_currentIndexChanged(const QString &arg1);
+    void on_strategyCombo_currentIndexChanged(int arg1);
 
     void on_refreshNumberBox_valueChanged(int arg1);
 

--- a/src/ui/widgets/editors/w_RoutesEditor.cpp
+++ b/src/ui/widgets/editors/w_RoutesEditor.cpp
@@ -409,10 +409,10 @@ void RouteEditor::on_addOutboundBtn_clicked()
     }
 }
 
-void RouteEditor::on_domainStrategyCombo_currentIndexChanged(const QString &arg1)
+void RouteEditor::on_domainStrategyCombo_currentIndexChanged(int arg1)
 {
     LOADINGCHECK
-    domainStrategy = arg1;
+    domainStrategy = domainStrategyCombo->itemText(arg1);
 }
 
 void RouteEditor::on_defaultOutboundCombo_currentTextChanged(const QString &arg1)

--- a/src/ui/widgets/editors/w_RoutesEditor.hpp
+++ b/src/ui/widgets/editors/w_RoutesEditor.hpp
@@ -51,7 +51,7 @@ class RouteEditor
     void on_buttonBox_accepted();
     void on_debugPainterCB_clicked(bool checked);
     void on_defaultOutboundCombo_currentTextChanged(const QString &arg1);
-    void on_domainStrategyCombo_currentIndexChanged(const QString &arg1);
+    void on_domainStrategyCombo_currentIndexChanged(int arg1);
     void on_importExistingBtn_clicked();
     void on_importGroupBtn_currentIndexChanged(int index);
     void on_insertBlackBtn_clicked();

--- a/src/ui/widgets/widgets/StreamSettingsWidget.cpp
+++ b/src/ui/widgets/widgets/StreamSettingsWidget.cpp
@@ -105,11 +105,6 @@ void StreamSettingsWidget::SetStreamObject(const StreamSettingsObject &sso)
     }
 }
 
-void StreamSettingsWidget::on_transportCombo_currentIndexChanged(int index)
-{
-    v2rayStackView->setCurrentIndex(index);
-}
-
 void StreamSettingsWidget::on_httpPathTxt_textEdited(const QString &arg1)
 {
     stream.httpSettings.path = arg1;
@@ -172,14 +167,14 @@ void StreamSettingsWidget::on_tcpFastOpenCB_stateChanged(int arg1)
     stream.sockopt.tcpFastOpen = arg1 == Qt::Checked;
 }
 
-void StreamSettingsWidget::on_tProxyCB_currentIndexChanged(const QString &arg1)
+void StreamSettingsWidget::on_tProxyCB_currentIndexChanged(int arg1)
 {
-    stream.sockopt.tproxy = arg1;
+    stream.sockopt.tproxy = tProxyCB->itemText(arg1);
 }
 
-void StreamSettingsWidget::on_quicSecurityCB_currentTextChanged(const QString &arg1)
+void StreamSettingsWidget::on_quicSecurityCB_currentIndexChanged(int arg1)
 {
-    stream.quicSettings.security = arg1;
+    stream.quicSettings.security = quicSecurityCB->itemText(arg1);
 }
 
 void StreamSettingsWidget::on_quicKeyTxt_textEdited(const QString &arg1)
@@ -187,14 +182,14 @@ void StreamSettingsWidget::on_quicKeyTxt_textEdited(const QString &arg1)
     stream.quicSettings.key = arg1;
 }
 
-void StreamSettingsWidget::on_quicHeaderTypeCB_currentIndexChanged(const QString &arg1)
+void StreamSettingsWidget::on_quicHeaderTypeCB_currentIndexChanged(int arg1)
 {
-    stream.quicSettings.header.type = arg1;
+    stream.quicSettings.header.type = quicHeaderTypeCB->itemText(arg1);
 }
 
-void StreamSettingsWidget::on_tcpHeaderTypeCB_currentIndexChanged(const QString &arg1)
+void StreamSettingsWidget::on_tcpHeaderTypeCB_currentIndexChanged(int arg1)
 {
-    stream.tcpSettings.header.type = arg1;
+    stream.tcpSettings.header.type = tcpHeaderTypeCB->itemText(arg1);
 }
 
 void StreamSettingsWidget::on_wsPathTxt_textEdited(const QString &arg1)
@@ -237,9 +232,9 @@ void StreamSettingsWidget::on_kcpWriteBufferSB_valueChanged(int arg1)
     stream.kcpSettings.writeBufferSize = arg1;
 }
 
-void StreamSettingsWidget::on_kcpHeaderType_currentTextChanged(const QString &arg1)
+void StreamSettingsWidget::on_kcpHeaderType_currentIndexChanged(int arg1)
 {
-    stream.kcpSettings.header.type = arg1;
+    stream.kcpSettings.header.type = kcpHeaderType->itemText(arg1);
 }
 
 void StreamSettingsWidget::on_kcpSeedTxt_textEdited(const QString &arg1)
@@ -270,14 +265,15 @@ void StreamSettingsWidget::on_tcpResponseEditBtn_clicked()
     stream.tcpSettings.header.response = tcpRspObject;
 }
 
-void StreamSettingsWidget::on_transportCombo_currentIndexChanged(const QString &arg1)
+void StreamSettingsWidget::on_transportCombo_currentIndexChanged(int arg1)
 {
-    stream.network = arg1;
+    stream.network = transportCombo->itemText(arg1);
+    v2rayStackView->setCurrentIndex(arg1);
 }
 
-void StreamSettingsWidget::on_securityTypeCB_currentIndexChanged(const QString &arg1)
+void StreamSettingsWidget::on_securityTypeCB_currentIndexChanged(int arg1)
 {
-    stream.security = arg1.toLower();
+    stream.security = securityTypeCB->itemText(arg1).toLower();
 }
 
 //

--- a/src/ui/widgets/widgets/StreamSettingsWidget.hpp
+++ b/src/ui/widgets/widgets/StreamSettingsWidget.hpp
@@ -26,7 +26,7 @@ class StreamSettingsWidget
 
     void on_kcpCongestionCB_stateChanged(int arg1);
     void on_kcpDownCapacitySB_valueChanged(int arg1);
-    void on_kcpHeaderType_currentTextChanged(const QString &arg1);
+    void on_kcpHeaderType_currentIndexChanged(int arg1);
     void on_kcpMTU_valueChanged(int arg1);
     void on_kcpReadBufferSB_valueChanged(int arg1);
     void on_kcpSeedTxt_textEdited(const QString &arg1);
@@ -34,28 +34,27 @@ class StreamSettingsWidget
     void on_kcpUploadCapacSB_valueChanged(int arg1);
     void on_kcpWriteBufferSB_valueChanged(int arg1);
 
-    void on_quicHeaderTypeCB_currentIndexChanged(const QString &arg1);
+    void on_quicHeaderTypeCB_currentIndexChanged(int arg1);
     void on_quicKeyTxt_textEdited(const QString &arg1);
-    void on_quicSecurityCB_currentTextChanged(const QString &arg1);
+    void on_quicSecurityCB_currentIndexChanged(int arg1);
 
     void on_allowInsecureCB_stateChanged(int arg1);
     void on_alpnTxt_textEdited(const QString &arg1);
     void on_disableSessionResumptionCB_stateChanged(int arg1);
-    void on_securityTypeCB_currentIndexChanged(const QString &arg1);
+    void on_securityTypeCB_currentIndexChanged(int arg1);
     void on_serverNameTxt_textEdited(const QString &arg1);
 
     void on_tcpFastOpenCB_stateChanged(int arg1);
-    void on_tcpHeaderTypeCB_currentIndexChanged(const QString &arg1);
+    void on_tcpHeaderTypeCB_currentIndexChanged(int arg1);
     void on_tcpRequestDefBtn_clicked();
     void on_tcpRequestEditBtn_clicked();
     void on_tcpRespDefBtn_clicked();
     void on_tcpResponseEditBtn_clicked();
 
-    void on_tProxyCB_currentIndexChanged(const QString &arg1);
+    void on_tProxyCB_currentIndexChanged(int arg1);
     void on_soMarkSpinBox_valueChanged(int arg1);
 
-    void on_transportCombo_currentIndexChanged(const QString &arg1);
-    void on_transportCombo_currentIndexChanged(int index);
+    void on_transportCombo_currentIndexChanged(int arg1);
 
     void on_wsHeadersTxt_textChanged();
     void on_wsPathTxt_textEdited(const QString &arg1);

--- a/src/ui/widgets/widgets/complex/ChainEditorWidget.cpp
+++ b/src/ui/widgets/widgets/complex/ChainEditorWidget.cpp
@@ -194,9 +194,9 @@ std::tuple<bool, QString, QStringList> ChainEditorWidget::VerifyChainLinkedList(
     return { false, tr("There's an error in your connection."), resultList };
 }
 
-void ChainEditorWidget::on_chainComboBox_currentIndexChanged(const QString &arg1)
+void ChainEditorWidget::on_chainComboBox_currentIndexChanged(int arg1)
 {
-    currentChain = chains[arg1];
+    currentChain = chains[chainComboBox->itemText(arg1)];
     ShowChainLinkedList();
 }
 

--- a/src/ui/widgets/widgets/complex/ChainEditorWidget.hpp
+++ b/src/ui/widgets/widgets/complex/ChainEditorWidget.hpp
@@ -31,7 +31,7 @@ class ChainEditorWidget
     void changeEvent(QEvent *e);
 
   private slots:
-    void on_chainComboBox_currentIndexChanged(const QString &arg1);
+    void on_chainComboBox_currentIndexChanged(int arg1);
     //
     void OnDispatcherChainedOutboundCreated(std::shared_ptr<OutboundObjectMeta>, QtNodes::Node &);
     void OnDispatcherChainedOutboundDeleted(const OutboundObjectMeta &);

--- a/src/ui/widgets/windows/w_GroupManager.cpp
+++ b/src/ui/widgets/windows/w_GroupManager.cpp
@@ -518,7 +518,7 @@ void GroupManager::on_connectionsTable_customContextMenuRequested(const QPoint &
     connectionListRCMenu->popup(QCursor::pos());
 }
 
-void GroupManager::on_subscriptionTypeCB_currentIndexChanged(const QString &)
+void GroupManager::on_subscriptionTypeCB_currentIndexChanged(int)
 {
     ConnectionManager->SetSubscriptionType(currentGroupId, subscriptionTypeCB->currentData().toString());
 }

--- a/src/ui/widgets/windows/w_GroupManager.hpp
+++ b/src/ui/widgets/windows/w_GroupManager.hpp
@@ -58,7 +58,7 @@ class GroupManager
     void on_deleteSelectedConnBtn_clicked();
     void on_exportSelectedConnBtn_clicked();
     void on_connectionsTable_customContextMenuRequested(const QPoint &pos);
-    void on_subscriptionTypeCB_currentIndexChanged(const QString &arg1);
+    void on_subscriptionTypeCB_currentIndexChanged(int arg1);
 
   private:
     void updateColorScheme() override;

--- a/src/ui/widgets/windows/w_PreferencesWindow.cpp
+++ b/src/ui/widgets/windows/w_PreferencesWindow.cpp
@@ -601,10 +601,10 @@ void PreferencesWindow::on_setSysProxyCB_stateChanged(int arg1)
     CurrentConfig.inboundConfig.systemProxySettings.setSystemProxy = arg1 == Qt::Checked;
 }
 
-void PreferencesWindow::on_autoStartSubsCombo_currentIndexChanged(const QString &arg1)
+void PreferencesWindow::on_autoStartSubsCombo_currentIndexChanged(int arg1)
 {
     LOADINGCHECK
-    if (arg1.isEmpty())
+    if (arg1 == -1)
     {
         CurrentConfig.autoStartId.clear();
         autoStartConnCombo->clear();
@@ -621,10 +621,10 @@ void PreferencesWindow::on_autoStartSubsCombo_currentIndexChanged(const QString 
     }
 }
 
-void PreferencesWindow::on_autoStartConnCombo_currentIndexChanged(const QString &arg1)
+void PreferencesWindow::on_autoStartConnCombo_currentIndexChanged(int arg1)
 {
     LOADINGCHECK
-    if (arg1.isEmpty())
+    if (arg1 == -1)
     {
         CurrentConfig.autoStartId.clear();
     }
@@ -653,10 +653,10 @@ void PreferencesWindow::SetAutoStartButtonsState(bool isAutoStart)
     startWithLoginCB->setChecked(isAutoStart);
 }
 
-void PreferencesWindow::on_fpTypeCombo_currentIndexChanged(const QString &arg1)
+void PreferencesWindow::on_fpTypeCombo_currentIndexChanged(int arg1)
 {
     LOADINGCHECK
-    CurrentConfig.defaultRouteConfig.forwardProxyConfig.type = arg1.toLower();
+    CurrentConfig.defaultRouteConfig.forwardProxyConfig.type = fpTypeCombo->itemText(arg1).toLower();
 }
 
 void PreferencesWindow::on_fpAddressTx_textEdited(const QString &arg1)

--- a/src/ui/widgets/windows/w_PreferencesWindow.hpp
+++ b/src/ui/widgets/windows/w_PreferencesWindow.hpp
@@ -73,9 +73,9 @@ class PreferencesWindow
     void on_darkThemeCB_stateChanged(int arg1);
     void on_darkTrayCB_stateChanged(int arg1);
     void on_setSysProxyCB_stateChanged(int arg1);
-    void on_autoStartSubsCombo_currentIndexChanged(const QString &arg1);
-    void on_autoStartConnCombo_currentIndexChanged(const QString &arg1);
-    void on_fpTypeCombo_currentIndexChanged(const QString &arg1);
+    void on_autoStartSubsCombo_currentIndexChanged(int arg1);
+    void on_autoStartConnCombo_currentIndexChanged(int arg1);
+    void on_fpTypeCombo_currentIndexChanged(int arg1);
     void on_fpAddressTx_textEdited(const QString &arg1);
     void on_fpUseAuthCB_stateChanged(int arg1);
     void on_fpUsernameTx_textEdited(const QString &arg1);


### PR DESCRIPTION
…QString&)

According to the documentation[1], it seems that there is no signal defined as "currentIndexChanged(const QString&)" but "currentTextChanged(const QString&)" for QComboBox, which makes some streamsettings unchangeable.

1. https://doc.qt.io/qt-6/qcombobox.html#signals