### PR TITLE
Fix tree-shaking default values

### DIFF
--- a/src/base/models/CoreObjectModels.hpp
+++ b/src/base/models/CoreObjectModels.hpp
@@ -197,12 +197,12 @@ namespace Qv2ray::base::objects
         struct KCPObject
         {
             int mtu = 1350;
-            int tti = 20;
+            int tti = 50;
             int uplinkCapacity = 5;
             int downlinkCapacity = 20;
             bool congestion = false;
-            int readBufferSize = 1;
-            int writeBufferSize = 1;
+            int readBufferSize = 2;
+            int writeBufferSize = 2;
             QString seed;
             ObfsHeaderObject header;
             KCPObject(){};
@@ -239,7 +239,7 @@ namespace Qv2ray::base::objects
         //
         struct QuicObject
         {
-            QString security;
+            QString security = "none";
             QString key;
             ObfsHeaderObject header;
             JSONSTRUCT_COMPARE(QuicObject, security, key, header)
@@ -249,7 +249,7 @@ namespace Qv2ray::base::objects
         //
         struct SockoptObject
         {
-            int mark = 255;
+            int mark = 0;
             bool tcpFastOpen = false;
             QString tproxy = "off";
             JSONSTRUCT_COMPARE(SockoptObject, mark, tcpFastOpen, tproxy)
@@ -275,7 +275,7 @@ namespace Qv2ray::base::objects
             bool allowInsecure = false;
             bool disableSessionResumption = true;
             bool disableSystemRoot = false;
-            QList<QString> alpn = { "http/1.1" };
+            QList<QString> alpn;
             QList<CertificateObject> certificates;
             JSONSTRUCT_COMPARE(TLSObject, serverName, allowInsecure, disableSessionResumption, disableSystemRoot, alpn, certificates)
             JSONSTRUCT_REGISTER(TLSObject, F(serverName, allowInsecure, disableSessionResumption, disableSystemRoot, alpn, certificates))
@@ -288,7 +288,7 @@ namespace Qv2ray::base::objects
             bool allowInsecure = false;
             bool disableSessionResumption = true;
             bool disableSystemRoot = false;
-            QList<QString> alpn = { "http/1.1" };
+            QList<QString> alpn;
             QList<CertificateObject> certificates;
             JSONSTRUCT_COMPARE(XTLSObject, serverName, allowInsecure, disableSessionResumption, disableSystemRoot, alpn, certificates)
             JSONSTRUCT_REGISTER(XTLSObject, F(serverName, allowInsecure, disableSessionResumption, disableSystemRoot, alpn, certificates))
@@ -346,7 +346,7 @@ namespace Qv2ray::base::objects
         struct ShadowSocksServerObject
         {
             QString address;
-            QString method = "aes-256-cfb";
+            QString method;
             QString password;
             int port;
             JSONSTRUCT_COMPARE(ShadowSocksServerObject, address, method, password)

--- a/src/base/models/QvCoreSettings.hpp
+++ b/src/base/models/QvCoreSettings.hpp
@@ -131,7 +131,8 @@ namespace Qv2ray::base::config
         JSONSTRUCT_COMPARE(QvConfig_Inbounds, listenip, useSocks, useHTTP, useTPROXY, tProxySettings, httpSettings, socksSettings,
                            systemProxySettings)
         JSONSTRUCT_REGISTER(QvConfig_Inbounds,                         //
+                            A(socksSettings),                          //
                             F(listenip, useSocks, useHTTP, useTPROXY), //
-                            F(tProxySettings, httpSettings, socksSettings, systemProxySettings))
+                            F(tProxySettings, httpSettings, systemProxySettings))
     };
 } // namespace Qv2ray::base::config

--- a/src/plugins/common/CommonTypes.hpp
+++ b/src/plugins/common/CommonTypes.hpp
@@ -46,7 +46,7 @@ struct HttpServerObject
 struct ShadowSocksServerObject
 {
     QString address = "0.0.0.0";
-    QString method = "chacha20-ietf-poly1305";
+    QString method = "aes-256-gcm";
     QString password;
     int port = 0;
     JSONSTRUCT_COMPARE(ShadowSocksServerObject, address, method, password)

--- a/src/plugins/protocols/ui/outbound/shadowsocks.ui
+++ b/src/plugins/protocols/ui/outbound/shadowsocks.ui
@@ -58,11 +58,6 @@
      </item>
      <item>
       <property name="text">
-       <string notr="true">chacha20-poly1305</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
        <string notr="true">chacha20-ietf-poly1305</string>
       </property>
      </item>


### PR DESCRIPTION
- fix: cannot change the state of `UDP support` and `UDP local IP` when socks port is 1089 by default
- fix: some preset values do not follow core default, and may be "shaken" accidentally
- remove `chacha20-poly1305` (alias of `chacha20-ietf-poly1305`) in passing