### PR TITLE
small updates and fixes

### DIFF
--- a/src/components/UpdateChecker/UpdateChecker.cpp
+++ b/src/components/UpdateChecker/UpdateChecker.cpp
@@ -8,8 +8,8 @@
 #include <QJsonDocument>
 
 const inline QStringList UpdateChannelLink{
-    /*{ 0, "https://api.github.com/repos/moodyhunter/QvPersonal/releases/latest" },*/
-    "https://api.github.com/repos/moodyhunter/QvPersonal/releases?per_page=1",
+    "https://api.github.com/repos/Qv2ray/Qv2ray/releases/latest",
+    "https://api.github.com/repos/Qv2ray/Qv2ray/releases?per_page=1",
 };
 
 using namespace Qv2rayBase;

--- a/src/models/SettingsModels.hpp
+++ b/src/models/SettingsModels.hpp
@@ -42,7 +42,7 @@ namespace Qv2ray::Models
             AUTOCONNECT_LAST_CONNECTED = 2
         };
         Bindable<LatencyTestEngineId> DefaultLatencyTestEngine;
-        Bindable<KernelId> DefaultKernelId;
+        Bindable<KernelId> DefaultKernelId = KernelId{ "v2ray5_kernel" };
         Bindable<AutoConnectBehavior> AutoConnectBehavior{ AUTOCONNECT_LAST_CONNECTED };
         Bindable<bool> QuietMode{ false };
         Bindable<ProfileId> AutoConnectProfileId;

--- a/src/plugins/v2ray/common/CommonHelpers.cpp
+++ b/src/plugins/v2ray/common/CommonHelpers.cpp
@@ -19,7 +19,6 @@ std::pair<bool, std::optional<QString>> ValidateKernel(const QString &corePath, 
 
     coreFile.close();
 
-    //
     // Check file existance.
     // From: https://www.v2fly.org/chapter_02/env.html#asset-location
     bool hasGeoIP = QDir(assetsPath).entryList().contains(u"geoip.dat"_qs);
@@ -36,15 +35,7 @@ std::pair<bool, std::optional<QString>> ValidateKernel(const QString &corePath, 
 
     // Check if V2Ray core returns a version number correctly.
     QProcess proc;
-    //#ifdef Q_OS_WIN32
-    //    // nativeArguments are required for Windows platform, without a reason...
-    //    proc.setProcessChannelMode(QProcess::MergedChannels);
-    //    proc.setProgram(corePath);
-    //    proc.setNativeArguments(u"--version"_qs);
-    //    proc.start();
-    //#else
     proc.start(corePath, arguments);
-    //#endif
     proc.waitForStarted();
     proc.waitForFinished();
     auto exitCode = proc.exitCode();

--- a/src/plugins/v2ray/core/V2RayRust/Kernel.cpp
+++ b/src/plugins/v2ray/core/V2RayRust/Kernel.cpp
@@ -139,7 +139,7 @@ std::optional<QString> V2RayRustKernel::ValidateConfig(const QString &path)
         QProcess process;
         process.setProcessEnvironment(env);
         process.setProcessChannelMode(QProcess::MergedChannels);
-        V2RayCorePluginClass::Log(u"Starting V2Ray core with test options"_qs);
+        V2RayCorePluginClass::Log(u"Starting V2Ray Rust with test options"_qs);
         process.start(settings.CorePath, { u"--test"_qs, u"--config"_qs, path }, QIODevice::ReadWrite | QIODevice::Text);
         process.waitForFinished();
 

--- a/src/plugins/v2ray/core/V2RayRust/ProfileGenerator.cpp
+++ b/src/plugins/v2ray/core/V2RayRust/ProfileGenerator.cpp
@@ -109,8 +109,6 @@ QByteArray V2RayRustProfileGenerator::Generate()
     for (const auto &rule : profile.routing.rules)
         ProcessRoutingRule(rule);
 
-    // Override log level
-    const auto settings = V2RayCorePluginClass::PluginInstance->settings;
 #define AddToRootTable(name) AddToTable(root_table, #name, name)
     AddToRootTable(trojan);
     AddToTable(root_table, "ss", shadowsocks);
@@ -128,7 +126,10 @@ QByteArray V2RayRustProfileGenerator::Generate()
     AddToRootTable(ip_routing_rules);
     AddToRootTable(geosite_rules);
     AddToRootTable(geoip_rules);
+#undef AddToRootTable
 
+    // Override log level
+    const auto settings = V2RayCorePluginClass::PluginInstance->settings;
     if (settings.APIEnabled)
     {
         root_table.emplace<bool>("enable_api_server", true);
@@ -474,7 +475,7 @@ void V2RayRustProfileGenerator::ProcessOutboundConfig(const OutboundObject &out)
 
 void V2RayRustProfileGenerator::ProcessBalancerConfig(const OutboundObject &out)
 {
-    // not support
+    // not supported
 }
 
 QJsonObject V2RayRustProfileGenerator::GenerateStreamSettings(const IOStreamSettings &stream)

--- a/src/plugins/v2ray/core/V2RayRust/ProfileGenerator.cpp
+++ b/src/plugins/v2ray/core/V2RayRust/ProfileGenerator.cpp
@@ -137,7 +137,6 @@ QByteArray V2RayRustProfileGenerator::Generate()
     QByteArray byteArray;
     QByteArrayAppender appender{ byteArray };
     appender << root_table;
-    V2RayCorePluginClass::Log(u"v2ray-rust root_table: "_qs + QString::fromUtf8(byteArray));
     return byteArray;
 }
 

--- a/src/ui/windows/w_PreferencesWindow.cpp
+++ b/src/ui/windows/w_PreferencesWindow.cpp
@@ -257,8 +257,27 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QvDialog(u"PreferenceWin
             defaultKernelCB->setCurrentIndex(index);
         else if (defaultKernelCB->count() > 0)
         {
-            AppConfig.behaviorConfig->DefaultKernelId = KernelId{ defaultKernelCB->itemData(0).toString() };
-            GlobalConfig->behaviorConfig->DefaultKernelId = AppConfig.behaviorConfig->DefaultKernelId;
+            // Try using these kernels by default, if they present, in order of preference.
+            // Otherwise, use the first one available.
+            static QStringList defaultKernelOrder{ "v2ray5_kernel", "v2ray_kernel" };
+            bool defaultKernelDeduced = false;
+            for (const auto k : defaultKernelOrder)
+            {
+                if (const auto kindex = defaultKernelCB->findData(k); kindex > 0)
+                {
+                    defaultKernelDeduced = true;
+                    defaultKernelCB->setCurrentIndex(kindex);
+                    AppConfig.behaviorConfig->DefaultKernelId = KernelId{ k };
+                    GlobalConfig->behaviorConfig->DefaultKernelId = AppConfig.behaviorConfig->DefaultKernelId;
+                    break;
+                }
+            }
+
+            if (!defaultKernelDeduced)
+            {
+                AppConfig.behaviorConfig->DefaultKernelId = KernelId{ defaultKernelCB->itemData(0).toString() };
+                GlobalConfig->behaviorConfig->DefaultKernelId = AppConfig.behaviorConfig->DefaultKernelId;
+            }
         }
 
         defaultKernelCB->blockSignals(false);


### PR DESCRIPTION
- UpdateChecker now checks for updates from the correct repository
- V2RayRust kernel will not dump your configurations into the log anymore (**PRIVACY!**) 
- The default kernel is now `v2ray5`
- The default kernel in the preference window will be deduced in a predefined order, instead of using the first one available. (new-user friendly)