### PR TITLE
Adapt to v2ray 5.1.0-2

### DIFF
--- a/src/core/kernel/V2RayKernelInteractions.cpp
+++ b/src/core/kernel/V2RayKernelInteractions.cpp
@@ -132,10 +132,10 @@ namespace Qv2ray::core::kernel
         // reason...
         proc.setProcessChannelMode(QProcess::MergedChannels);
         proc.setProgram(corePath);
-        proc.setNativeArguments("--version");
+        proc.setNativeArguments("version");
         proc.start();
 #else
-        proc.start(corePath, { "--version" });
+        proc.start(corePath, { "version" });
 #endif
         proc.waitForStarted();
         proc.waitForFinished();
@@ -168,7 +168,7 @@ namespace Qv2ray::core::kernel
             QProcess process;
             process.setProcessEnvironment(env);
             DEBUG("Starting V2Ray core with test options");
-            process.start(kernelPath, { "-test", "-config", path }, QIODevice::ReadWrite | QIODevice::Text);
+            process.start(kernelPath, { "test", "-config", path }, QIODevice::ReadWrite | QIODevice::Text);
             process.waitForFinished();
 
             if (process.exitCode() != 0)
@@ -232,7 +232,7 @@ namespace Qv2ray::core::kernel
         env.insert("v2ray.location.asset", GlobalConfig.kernelConfig.AssetsPath());
         env.insert("XRAY_LOCATION_ASSET", GlobalConfig.kernelConfig.AssetsPath());
         vProcess->setProcessEnvironment(env);
-        vProcess->start(GlobalConfig.kernelConfig.KernelPath(), { "-config", filePath }, QIODevice::ReadWrite | QIODevice::Text);
+        vProcess->start(GlobalConfig.kernelConfig.KernelPath(), { "run", "-config", filePath }, QIODevice::ReadWrite | QIODevice::Text);
         vProcess->waitForStarted();
         kernelStarted = true;
 


### PR DESCRIPTION
When I use it with the latest v2ray, it says "V2Ray core failed with an exit code: 2". I found the reason is the change of parameter format of v2ray-core.

So I changed kernel parameter format in file "V2RayKernelInteractions.cpp". Now it works properly. I've tested it on both Archlinux and Windows11.