### PR TITLE
add trojan link & outbound support

### DIFF
--- a/.github/workflows/build-qv2ray-cmake.yml
+++ b/.github/workflows/build-qv2ray-cmake.yml
@@ -112,10 +112,10 @@ jobs:
           cd ./libs
           ./setup-libs.sh windows ${{ matrix.arch }}
       # ========================================================================================================= Generate MakeFile and Build
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         if: matrix.platform == 'macos-latest'
         with:
-          node-version: "12.x"
+          node-version: "16"
       - run: npm install -g appdmg
         if: matrix.platform == 'macos-latest'
       - name: macOS - ${{ matrix.qt_version }} - Generate Dependencies and Build

--- a/cmake/components/qv2ray-base.cmake
+++ b/cmake/components/qv2ray-base.cmake
@@ -81,6 +81,7 @@ set(QV2RAY_BASE_SOURCES
     ${QV2RAY_BASEDIR_CORE}/connection/serialization/vmess.cpp
     ${QV2RAY_BASEDIR_CORE}/connection/serialization/vmess_new.cpp
     ${QV2RAY_BASEDIR_CORE}/connection/serialization/vless.cpp
+    ${QV2RAY_BASEDIR_CORE}/connection/serialization/trojan.cpp
     #
     ${QV2RAY_BASEDIR_CORE}/CoreUtils.cpp
     ${QV2RAY_BASEDIR_CORE}/CoreUtils.hpp

--- a/src/base/models/CoreObjectModels.hpp
+++ b/src/base/models/CoreObjectModels.hpp
@@ -398,5 +398,15 @@ namespace Qv2ray::base::objects
             JSONSTRUCT_COMPARE(ShadowSocksServerObject, address, method, password)
             JSONSTRUCT_REGISTER(ShadowSocksServerObject, F(address, port, method, password))
         };
+        //
+        // Trojan Server
+        struct TrojanServerObject
+        {
+            QString address;
+            QString password;
+            int port;
+            JSONSTRUCT_COMPARE(TrojanServerObject, address, password)
+            JSONSTRUCT_REGISTER(TrojanServerObject, F(address, port, password))
+        };
     } // namespace protocol
 } // namespace Qv2ray::base::objects

--- a/src/core/connection/Generation.hpp
+++ b/src/core/connection/Generation.hpp
@@ -45,6 +45,8 @@ namespace Qv2ray::core::connection::generation
         OUTBOUNDSETTING GenerateBlackHoleOUT(bool useHTTP);
         OUTBOUNDSETTING GenerateShadowSocksOUT(const QList<ShadowSocksServerObject> &servers);
         OUTBOUNDSETTING GenerateShadowSocksServerOUT(const QString &address, int port, const QString &method, const QString &password);
+        OUTBOUNDSETTING GenerateTrojanOUT(const QList<TrojanServerObject> &servers);
+        OUTBOUNDSETTING GenerateTrojanServerOUT(const QString &address, int port, const QString &password);
         OUTBOUNDSETTING GenerateHTTPSOCKSOut(const QString &address, int port, bool useAuth, const QString &username, const QString &password);
         OUTBOUND GenerateOutboundEntry(const QString &tag,                //
                                        const QString &protocol,           //

--- a/src/core/connection/Serialization.cpp
+++ b/src/core/connection/Serialization.cpp
@@ -35,6 +35,12 @@ namespace Qv2ray::core::connection
                 TLSOptionsFilter(conf);
                 connectionConf << std::pair{ *aliasPrefix, conf };
             }
+            else if (link.startsWith("trojan://"))
+            {
+                auto conf = trojan::Deserialize(link, aliasPrefix, errMessage);
+                TLSOptionsFilter(conf);
+                connectionConf << std::pair{ *aliasPrefix, conf };
+            }
             else if (link.startsWith("ss://") && !link.contains("plugin="))
             {
                 auto conf = ss::Deserialize(link, aliasPrefix, errMessage);
@@ -108,6 +114,11 @@ namespace Qv2ray::core::connection
             {
                 auto ssServer = ShadowSocksServerObject::fromJson(settings["servers"].toArray().first().toObject());
                 sharelink = ss::Serialize(ssServer, alias, isSip002);
+            }
+            else if (type == "trojan")
+            {
+                auto trojanServer = TrojanServerObject::fromJson(settings["servers"].toArray().first().toObject());
+                sharelink = trojan::Serialize(trojanServer, alias);
             }
             else
             {

--- a/src/core/connection/Serialization.hpp
+++ b/src/core/connection/Serialization.hpp
@@ -34,6 +34,12 @@ namespace Qv2ray::core::connection::serialization
         CONFIGROOT Deserialize(const QString &vless, QString *alias, QString *errMessage);
     } // namespace vless
 
+    namespace trojan
+    {
+        CONFIGROOT Deserialize(const QString &trojan, QString *alias, QString *errMessage);
+        const QString Serialize(const TrojanServerObject &server, const QString &alias);
+    } // namespace trojan
+
     namespace ss
     {
         CONFIGROOT Deserialize(const QString &ss, QString *alias, QString *errMessage);

--- a/src/core/connection/generation/outbounds.cpp
+++ b/src/core/connection/generation/outbounds.cpp
@@ -38,6 +38,27 @@ namespace Qv2ray::core::connection::generation::outbounds
         return root;
     }
 
+    OUTBOUNDSETTING GenerateTrojanOUT(const QList<TrojanServerObject> &_servers)
+    {
+        OUTBOUNDSETTING root;
+        QJsonArray x;
+
+        for (const auto &server : _servers)
+        {
+            x.append(GenerateTrojanServerOUT(server.address, server.port, server.password));
+        }
+
+        root.insert("servers", x);
+        return root;
+    }
+
+    OUTBOUNDSETTING GenerateTrojanServerOUT(const QString &address, int port, const QString &password)
+    {
+        OUTBOUNDSETTING root;
+        JADD(address, port, password)
+        return root;
+    }
+
     OUTBOUNDSETTING GenerateHTTPSOCKSOut(const QString &addr, int port, bool useAuth, const QString &username, const QString &password)
     {
         OUTBOUNDSETTING root;

--- a/src/core/connection/serialization/trojan.cpp
+++ b/src/core/connection/serialization/trojan.cpp
@@ -1,0 +1,93 @@
+#include "core/CoreUtils.hpp"
+#include "core/connection/Generation.hpp"
+#include "core/connection/Serialization.hpp"
+#include "utils/QvHelpers.hpp"
+
+#define QV_MODULE_NAME "TrojanImporter"
+
+namespace Qv2ray::core::connection
+{
+    namespace serialization::trojan
+    {
+        CONFIGROOT Deserialize(const QString &trojanUri, QString *alias, QString *errMessage)
+        {
+            TrojanServerObject server;
+            QString d_name;
+
+            // auto ssUri = _ssUri.toStdString();
+            if (trojanUri.length() < 5)
+            {
+                LOG("trojan:// string too short");
+                *errMessage = QObject::tr("SS URI is too short");
+            }
+
+            auto uri = trojanUri.mid(5);
+            auto hashPos = uri.lastIndexOf("#");
+            DEBUG("Hash sign position: " + QSTRN(hashPos));
+
+            if (hashPos >= 0)
+            {
+                // Get the name/remark
+                d_name = uri.mid(uri.lastIndexOf("#") + 1);
+                uri.truncate(hashPos);
+            }
+
+            auto atPos = uri.indexOf('@');
+            DEBUG("At sign position: " + QSTRN(atPos));
+
+            if (atPos < 0)
+            {
+                QString decoded = QByteArray::fromBase64(uri.toUtf8(), QByteArray::Base64Option::OmitTrailingEquals);
+                atPos = decoded.lastIndexOf('@');
+                DEBUG("At sign position: " + QSTRN(atPos));
+
+                if (atPos < 0)
+                {
+                    *errMessage = QObject::tr("Can't find the at separator between password and hostname");
+                }
+
+                server.password = decoded.mid(0, atPos);
+                decoded.remove(0, atPos + 1);
+                auto colonPos = decoded.lastIndexOf(':');
+                DEBUG("Colon position: " + QSTRN(colonPos));
+
+                if (colonPos < 0)
+                {
+                    *errMessage = QObject::tr("Can't find the colon separator between hostname and port");
+                }
+
+                server.address = decoded.mid(0, colonPos);
+                server.port = decoded.mid(colonPos + 1).toInt();
+            }
+            else
+            {
+                auto x = QUrl::fromUserInput(uri);
+                server.address = x.host();
+                server.port = x.port();
+                server.password = x.userName();
+            }
+
+            d_name = QUrl::fromPercentEncoding(d_name.toUtf8());
+            CONFIGROOT root;
+            OUTBOUNDS outbounds;
+            outbounds.append(GenerateOutboundEntry(OUTBOUND_TAG_PROXY, "trojan", GenerateTrojanOUT({ server }), {}));
+            JADD(outbounds)
+            *alias = alias->isEmpty() ? d_name : *alias + "_" + d_name;
+            LOG("Deduced alias: " + *alias);
+            return root;
+        }
+
+        const QString Serialize(const TrojanServerObject &server, const QString &alias)
+        {
+            QUrl url;
+            const auto userinfo = server.password;
+            url.setUserInfo(userinfo);
+            url.setScheme("trojan");
+            url.setHost(server.address);
+            url.setPort(server.port);
+            url.setFragment(alias);
+            return url.toString(QUrl::ComponentFormattingOption::FullyEncoded);
+        }
+    } // namespace serialization::trojan
+} // namespace Qv2ray::core::connection
+

--- a/src/plugins/common/CommonTypes.hpp
+++ b/src/plugins/common/CommonTypes.hpp
@@ -60,7 +60,7 @@ struct TrojanServerObject
 {
     QString address = "0.0.0.0";
     QString password;
-    int port = 0;
+    int port = 443;
     JSONSTRUCT_COMPARE(TrojanServerObject, address, password)
     JSONSTRUCT_REGISTER(TrojanServerObject, F(address, port, password))
 };

--- a/src/plugins/common/CommonTypes.hpp
+++ b/src/plugins/common/CommonTypes.hpp
@@ -62,7 +62,7 @@ struct TrojanServerObject
     QString password;
     int port = 443;
     JSONSTRUCT_COMPARE(TrojanServerObject, address, password)
-    JSONSTRUCT_REGISTER(TrojanServerObject, F(address, port, password))
+    JSONSTRUCT_REGISTER(TrojanServerObject, A(port), F(address, password))
 };
 
 //

--- a/src/plugins/common/CommonTypes.hpp
+++ b/src/plugins/common/CommonTypes.hpp
@@ -53,6 +53,18 @@ struct ShadowSocksServerObject
     JSONSTRUCT_REGISTER(ShadowSocksServerObject, A(method), F(address, port, password))
 };
 
+
+//
+// Trojan Server
+struct TrojanServerObject
+{
+    QString address = "0.0.0.0";
+    QString password;
+    int port = 0;
+    JSONSTRUCT_COMPARE(TrojanServerObject, address, password)
+    JSONSTRUCT_REGISTER(TrojanServerObject, F(address, port, password))
+};
+
 //
 // VLESS Server
 struct VLESSServerObject

--- a/src/plugins/protocols/QvPlugin-BuiltinProtocolSupport.cmake
+++ b/src/plugins/protocols/QvPlugin-BuiltinProtocolSupport.cmake
@@ -19,6 +19,7 @@ ADD_SOURCE(outbound socksout)
 ADD_SOURCE(outbound shadowsocks)
 ADD_SOURCE(outbound vless)
 ADD_SOURCE(outbound vmess)
+ADD_SOURCE(outbound trojan)
 ADD_SOURCE(outbound loopback)
 
 ADD_SOURCE(inbound dokodemo-door)

--- a/src/plugins/protocols/core/OutboundHandler.cpp
+++ b/src/plugins/protocols/core/OutboundHandler.cpp
@@ -41,12 +41,18 @@ const Qv2rayPlugin::OutboundInfoObject BuiltinSerializer::GetOutboundInfo(const 
         obj[INFO_SERVER] = ss.address;
         obj[INFO_PORT] = ss.port;
     }
+    else if (protocol == "trojan")
+    {
+        const auto ss = TrojanServerObject::fromJson(outbound["servers"].toArray().first());
+        obj[INFO_SERVER] = ss.address;
+        obj[INFO_PORT] = ss.port;
+    }
     return obj;
 }
 
 const void BuiltinSerializer::SetOutboundInfo(const QString &protocol, const Qv2rayPlugin::OutboundInfoObject &info, QJsonObject &outbound) const
 {
-    if ((QStringList{ "http", "socks", "shadowsocks" }).contains(protocol))
+    if ((QStringList{ "http", "socks", "shadowsocks", "trojan" }).contains(protocol))
     {
         QJsonIO::SetValue(outbound, info[INFO_SERVER].toString(), "servers", 0, "address");
         QJsonIO::SetValue(outbound, info[INFO_PORT].toInt(), "servers", 0, "port");

--- a/src/plugins/protocols/core/OutboundHandler.hpp
+++ b/src/plugins/protocols/core/OutboundHandler.hpp
@@ -14,6 +14,6 @@ class BuiltinSerializer : public Qv2rayPlugin::PluginOutboundHandler
     const QList<QString> SupportedLinkPrefixes() const override;
     const QList<QString> SupportedProtocols() const override
     {
-        return { "http", "socks", "shadowsocks", "vmess", "vless" };
+        return { "http", "socks", "shadowsocks", "vmess", "vless", "trojan" };
     }
 };

--- a/src/plugins/protocols/ui/Interface.hpp
+++ b/src/plugins/protocols/ui/Interface.hpp
@@ -14,6 +14,7 @@
 #include "outbound/socksout.hpp"
 #include "outbound/vless.hpp"
 #include "outbound/vmess.hpp"
+#include "outbound/trojan.hpp"
 
 using namespace Qv2rayPlugin;
 
@@ -45,6 +46,7 @@ class ProtocolGUIInterface : public PluginGUIInterface
     {
         return {
             MakeEditorInfoPair<VmessOutboundEditor>("vmess", "VMess"),                   //
+            MakeEditorInfoPair<TrojanOutboundEditor>("trojan", "Trojan"),                 //
             MakeEditorInfoPair<VlessOutboundEditor>("vless", "VLESS"),                   //
             MakeEditorInfoPair<ShadowsocksOutboundEditor>("shadowsocks", "Shadowsocks"), //
             MakeEditorInfoPair<HttpOutboundEditor>("http", "HTTP"),                      //

--- a/src/plugins/protocols/ui/outbound/trojan.cpp
+++ b/src/plugins/protocols/ui/outbound/trojan.cpp
@@ -1,0 +1,26 @@
+#include "trojan.hpp"
+
+#include "BuiltinProtocolPlugin.hpp"
+
+TrojanOutboundEditor::TrojanOutboundEditor(QWidget *parent) : Qv2rayPlugin::QvPluginEditor(parent)
+{
+    setupUi(this);
+    setProperty("QV2RAY_INTERNAL_HAS_STREAMSETTINGS", true);
+    setProperty("QV2RAY_INTERNAL_HAS_FORWARD_PROXY", true);
+}
+
+void TrojanOutboundEditor::changeEvent(QEvent *e)
+{
+    QWidget::changeEvent(e);
+    switch (e->type())
+    {
+        case QEvent::LanguageChange: retranslateUi(this); break;
+        default: break;
+    }
+}
+
+void TrojanOutboundEditor::on_passwordLineEdit_textEdited(const QString &arg1)
+{
+    PLUGIN_EDITOR_LOADING_GUARD
+    trojan.password = arg1;
+}

--- a/src/plugins/protocols/ui/outbound/trojan.hpp
+++ b/src/plugins/protocols/ui/outbound/trojan.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "CommonTypes.hpp"
+#include "QvGUIPluginInterface.hpp"
+#include "ui_trojan.h"
+
+class TrojanOutboundEditor
+    : public Qv2rayPlugin::QvPluginEditor
+    , private Ui::trojanOutEditor
+{
+    Q_OBJECT
+
+  public:
+    explicit TrojanOutboundEditor(QWidget *parent = nullptr);
+
+    void SetHostAddress(const QString &addr, int port) override
+    {
+        trojan.address = addr;
+        trojan.port = port;
+    }
+
+    QPair<QString, int> GetHostAddress() const override
+    {
+        return { trojan.address, trojan.port };
+    }
+
+    void SetContent(const QJsonObject &content) override
+    {
+        PLUGIN_EDITOR_LOADING_SCOPE({
+            if (content["servers"].toArray().isEmpty())
+                content["servers"] = QJsonArray{ QJsonObject{} };
+            // trojan Configs
+            trojan = TrojanServerObject::fromJson(content["servers"].toArray().first().toObject());
+            passwordLineEdit->setText(trojan.password);
+        })
+    }
+    const QJsonObject GetContent() const override
+    {
+        auto result = content;
+        QJsonArray servers;
+        servers.append(trojan.toJson());
+        result.insert("servers", servers);
+        return result;
+    }
+
+  private:
+    TrojanServerObject trojan;
+
+  protected:
+    void changeEvent(QEvent *e) override;
+
+  private slots:
+    void on_passwordLineEdit_textEdited(const QString &arg1);
+};

--- a/src/plugins/protocols/ui/outbound/trojan.ui
+++ b/src/plugins/protocols/ui/outbound/trojan.ui
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>trojanOutEditor</class>
+ <widget class="QWidget" name="trojanOutEditor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="passwordLabel">
+     <property name="text">
+      <string>Password</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="passwordLineEdit">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="maxLength">
+      <number>36</number>
+     </property>
+     <property name="placeholderText">
+      <string notr="true">p@ssw0rd</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ function(ADD_QV2RAY_TEST TEST_NAME TEST_SOURCE)
 endfunction()
 
 ADD_QV2RAY_TEST(parse_ss_url src/core/connection/TestParseSS.cpp)
+ADD_QV2RAY_TEST(parse_trojan_url src/core/connection/TestParseTrojan.cpp)
 ADD_QV2RAY_TEST(parse_vmess_url src/core/connection/TestParseVmess.cpp)
 ADD_QV2RAY_TEST(parse_vless_url src/core/connection/TestParseVLESS.cpp)
 ADD_QV2RAY_TEST(generation src/core/connection/TestGeneration.cpp)

--- a/test/src/core/connection/TestParseTrojan.cpp
+++ b/test/src/core/connection/TestParseTrojan.cpp
@@ -1,0 +1,35 @@
+#include "3rdparty/QJsonStruct/QJsonIO.hpp"
+#include "Common.hpp"
+#include "src/core/connection/Serialization.hpp"
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+using namespace Qv2ray::core::connection::serialization;
+
+SCENARIO("Test Parse trojan url", "[ParseTrojanUrl]")
+{
+    QvTestApplication app;
+    GIVEN("A trojan server object")
+    {
+        TrojanServerObject s;
+        QString err;
+        WHEN("simple url")
+        {
+            QString alias;
+            auto c = trojan::Deserialize("trojan://passω0rd@255.255.255.1:8192#evil", &alias, &err);
+            s = TrojanServerObject::fromJson(QJsonIO::GetValue(c, "outbounds", 0, "settings", "servers", 0));
+            REQUIRE(s.address.toStdString() == "255.255.255.1");
+            REQUIRE(s.port == 8192);
+            REQUIRE(s.password.toStdString() == "passω0rd");
+        }
+        WHEN("password containing special characters")
+        {
+            QString alias;
+            auto c = trojan::Deserialize("trojan://pAss:ω0rd@4.4.4.4:443#%E6%81%B6%E9%AD%94", &alias, &err);
+            s = TrojanServerObject::fromJson(QJsonIO::GetValue(c, "outbounds", 0, "settings", "servers", 0));
+            REQUIRE(s.address.toStdString() == "4.4.4.4");
+            REQUIRE(s.port == 443);
+            REQUIRE(s.password.toStdString() == "pAss:ω0rd");
+            REQUIRE(alias == "恶魔");
+        }
+    }
+}


### PR DESCRIPTION
The v2ray-core supports the trojan editor now, this PR makes qv2ray can edit trojan outbounds, with simple link formatting.