### PR TITLE
feat: custom core version

### DIFF
--- a/.github/workflows/build-qv2ray-cmake.yml
+++ b/.github/workflows/build-qv2ray-cmake.yml
@@ -123,7 +123,6 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 \
             -DDS_STORE_SCRIPT=ON \
-            -DQV2RAY_USE_V5_CORE=ON \
             -DQV2RAY_DEFAULT_VASSETS_PATH=/usr/local/opt/v2ray/share/v2ray \
             -DQV2RAY_DEFAULT_VCORE_PATH=/usr/local/opt/v2ray/bin/v2ray
           cmake --build . --parallel $(sysctl -n hw.logicalcpu)
@@ -141,7 +140,6 @@ jobs:
           cd build
           cmake .. -GNinja \
             -DCMAKE_INSTALL_PREFIX=./deployment \
-            -DQV2RAY_USE_V5_CORE=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           cmake --build . --parallel $(nproc)
           cmake --install .
@@ -155,7 +153,6 @@ jobs:
           cd build
           cmake .. -GNinja \
             -DCMAKE_INSTALL_PREFIX=./AppDir/usr \
-            -DQV2RAY_USE_V5_CORE=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DQV2RAY_TRANSLATION_PATH=QApplication::applicationDirPath\(\)+"/../share/qv2ray/lang"
           cmake --build . --parallel $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,9 +130,6 @@ option(QV2RAY_HAS_SINGLEAPPLICATION "Build With SingleApplication" ON)
 set(QV2RAY_UI_TYPE "QWidget" CACHE STRING "Qv2ray GUI Component")
 QVLOG(QV2RAY_UI_TYPE)
 
-option(QV2RAY_USE_V5_CORE "Use V5 Core" ON)
-QVLOG(QV2RAY_USE_V5_CORE)
-
 option(QV2RAY_QT6 "Use Qt6" OFF)
 
 if(QV2RAY_UI_TYPE STREQUAL "QWidget")
@@ -333,11 +330,6 @@ target_include_directories(qv2ray_baselib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${Protobuf_INCLUDE_DIRS}
     )
-
-if(QV2RAY_USE_V5_CORE)
-    message("-- Use V2Ray Core V5")
-    target_compile_definitions(qv2ray_baselib PUBLIC QV2RAY_USE_V5_CORE)
-endif()
 
 # ==================================================================================
 # Qv2ray Builtin Plugins

--- a/src/base/Qv2rayBase.hpp
+++ b/src/base/Qv2rayBase.hpp
@@ -63,9 +63,7 @@ using namespace Qv2ray::base::objects::transfer;
 #if !defined(QV2RAY_DEFAULT_VCORE_PATH) && !defined(QV2RAY_DEFAULT_VASSETS_PATH)
 #define QV2RAY_DEFAULT_VASSETS_PATH (QV2RAY_CONFIG_DIR + "vcore/")
 #define QV2RAY_DEFAULT_VCORE_PATH (QV2RAY_CONFIG_DIR + "vcore/v2ray" QV2RAY_EXECUTABLE_SUFFIX)
-#if !defined(QV2RAY_USE_V5_CORE)
-#define QV2RAY_DEFAULT_VCTL_PATH (QV2RAY_CONFIG_DIR + "vcore/v2ctl" QV2RAY_EXECUTABLE_SUFFIX)
-#endif
+// #define QV2RAY_DEFAULT_VCTL_PATH (QV2RAY_CONFIG_DIR + "vcore/v2ctl" QV2RAY_EXECUTABLE_SUFFIX)
 #elif defined(QV2RAY_DEFAULT_VCORE_PATH) && defined(QV2RAY_DEFAULT_VASSETS_PATH)
 // ---- Using user-specified VCore and VAssets path
 #else

--- a/src/base/models/QvSettingsObject.hpp
+++ b/src/base/models/QvSettingsObject.hpp
@@ -14,7 +14,7 @@ namespace Qv2ray::base::config
         int R = 150, G = 150, B = 150;
         float width = 1.5f;
         Qt::PenStyle style = Qt::SolidLine;
-        QvGraphPenConfig(){};
+        QvGraphPenConfig() {};
         QvGraphPenConfig(int R, int G, int B, float w, Qt::PenStyle s)
         {
             this->R = R;
@@ -64,8 +64,9 @@ namespace Qv2ray::base::config
         bool exitByCloseEvent = false;
         JSONSTRUCT_COMPARE(Qv2rayConfig_UI, theme, language, quietMode, graphConfig, useDarkTheme, useDarkTrayIcon, useGlyphTrayIcon, maximumLogLines,
                            maxJumpListCount, recentConnections, useOldShareLinkFormat, startMinimized, exitByCloseEvent)
-        JSONSTRUCT_REGISTER(Qv2rayConfig_UI, F(theme, language, quietMode, graphConfig, useDarkTheme, useDarkTrayIcon, useGlyphTrayIcon,
-                                               maximumLogLines, maxJumpListCount, recentConnections, useOldShareLinkFormat, startMinimized, exitByCloseEvent))
+        JSONSTRUCT_REGISTER(Qv2rayConfig_UI,
+                            F(theme, language, quietMode, graphConfig, useDarkTheme, useDarkTrayIcon, useGlyphTrayIcon, maximumLogLines,
+                              maxJumpListCount, recentConnections, useOldShareLinkFormat, startMinimized, exitByCloseEvent))
     };
 
     struct Qv2rayConfig_Plugin
@@ -75,6 +76,12 @@ namespace Qv2ray::base::config
         int portAllocationStart = 15000;
         JSONSTRUCT_COMPARE(Qv2rayConfig_Plugin, pluginStates, v2rayIntegration, portAllocationStart)
         JSONSTRUCT_REGISTER(Qv2rayConfig_Plugin, F(pluginStates, v2rayIntegration, portAllocationStart))
+    };
+
+    enum CoreVersion
+    {
+        COREVERSION_V2RAY_V5,
+        COREVERSION_V2RAY_V4
     };
 
     struct Qv2rayConfig_Kernel
@@ -88,6 +95,8 @@ namespace Qv2ray::base::config
         QString v2AssetsPath_macx;
         QString v2CorePath_win;
         QString v2AssetsPath_win;
+
+        CoreVersion coreVersion = (CoreVersion) 0;
 
 #ifdef Q_OS_LINUX
 #define _VARNAME_VCOREPATH_ v2CorePath_linux
@@ -113,11 +122,13 @@ namespace Qv2ray::base::config
 #undef _VARNAME_VASSETSPATH_
 
         JSONSTRUCT_COMPARE(Qv2rayConfig_Kernel, enableAPI, statsPort, //
+                           coreVersion,                               //
                            v2CorePath_linux, v2AssetsPath_linux,      //
                            v2CorePath_macx, v2AssetsPath_macx,        //
                            v2CorePath_win, v2AssetsPath_win)
         JSONSTRUCT_REGISTER(Qv2rayConfig_Kernel,                     //
                             F(enableAPI, statsPort),                 //
+                            F(coreVersion),                          //
                             F(v2CorePath_linux, v2AssetsPath_linux), //
                             F(v2CorePath_macx, v2AssetsPath_macx),   //
                             F(v2CorePath_win, v2AssetsPath_win))

--- a/src/core/kernel/V2RayKernelInteractions.hpp
+++ b/src/core/kernel/V2RayKernelInteractions.hpp
@@ -22,9 +22,9 @@ namespace Qv2ray::core::kernel
         }
         //
         static std::optional<QString> ValidateConfig(const QString &path);
-        static std::pair<bool, std::optional<QString>> ValidateKernel(const QString &vCorePath, const QString &vAssetsPath);
+        static std::pair<bool, std::optional<QString>> ValidateKernel(const Qv2ray::base::config::CoreVersion coreVersion, const QString &vCorePath, const QString &vAssetsPath);
 #if QV2RAY_FEATURE(kernel_check_permission)
-        static std::pair<bool, std::optional<QString>> CheckAndSetCoreExecutableState(const QString &vCorePath);
+        static std::pair<bool, std::optional<QString>> CheckAndSetCoreExecutableState(const Qv2ray::base::config::CoreVersion coreVersion, const QString &vCorePath);
 #endif
 
       signals:

--- a/src/core/settings/SettingsBackend.cpp
+++ b/src/core/settings/SettingsBackend.cpp
@@ -214,6 +214,7 @@ namespace Qv2ray::core::config
 
             GlobalConfig.kernelConfig.KernelPath(QV2RAY_DEFAULT_VCORE_PATH);
             GlobalConfig.kernelConfig.AssetsPath(QV2RAY_DEFAULT_VASSETS_PATH);
+            GlobalConfig.kernelConfig.coreVersion = Qv2ray::base::config::COREVERSION_V2RAY_V5;
             GlobalConfig.logLevel = 3;
             GlobalConfig.uiConfig.language = QLocale::system().name();
             GlobalConfig.defaultRouteConfig.dnsConfig.servers.append({ "1.1.1.1" });

--- a/src/ui/widgets/windows/w_PreferencesWindow.hpp
+++ b/src/ui/widgets/windows/w_PreferencesWindow.hpp
@@ -39,7 +39,7 @@ class PreferencesWindow
     }
 
   private:
-    void updateColorScheme() override{};
+    void updateColorScheme() override {};
     QvMessageBusSlotDecl override;
 
   private slots:
@@ -48,6 +48,7 @@ class PreferencesWindow
     void on_socksAuthCB_stateChanged(int arg1);
     void on_languageComboBox_currentTextChanged(const QString &arg1);
     void on_logLevelComboBox_currentIndexChanged(int index);
+    void on_coreVersionComboBox_currentIndexChanged(int index);
     void on_vCoreAssetsPathTxt_textEdited(const QString &arg1);
     void on_listenIPTxt_textEdited(const QString &arg1);
     void on_socksPortLE_valueChanged(int arg1);

--- a/src/ui/widgets/windows/w_PreferencesWindow.ui
+++ b/src/ui/widgets/windows/w_PreferencesWindow.ui
@@ -752,6 +752,42 @@ Qv2ray will give a more accurate latency value if Enabled, but makes it easy to 
            </widget>
           </item>
           <item row="1" column="0">
+           <widget class="QLabel" name="label_95">
+            <property name="text">
+             <string>Core Version</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="coreVersionComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>150</width>
+              <height>0</height>
+             </size>
+            </property>
+            <item>
+             <property name="text">
+              <string>5</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>4</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="0">
            <widget class="QLabel" name="label_46">
             <property name="text">
              <string>V2Ray Core Executable Path</string>
@@ -761,7 +797,7 @@ Qv2ray will give a more accurate latency value if Enabled, but makes it easy to 
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
              <widget class="QLineEdit" name="vCorePathTxt">
@@ -779,7 +815,7 @@ Qv2ray will give a more accurate latency value if Enabled, but makes it easy to 
             </item>
            </layout>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="label_15">
             <property name="text">
              <string>V2Ray Assets Directory</string>
@@ -789,7 +825,7 @@ Qv2ray will give a more accurate latency value if Enabled, but makes it easy to 
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <layout class="QHBoxLayout" name="horizontalLayout_7">
             <item>
              <widget class="QLineEdit" name="vCoreAssetsPathTxt"/>
@@ -803,21 +839,21 @@ Qv2ray will give a more accurate latency value if Enabled, but makes it easy to 
             </item>
            </layout>
           </item>
-          <item row="7" column="0" colspan="2">
+          <item row="8" column="0" colspan="2">
            <widget class="QPushButton" name="checkVCoreSettings">
             <property name="text">
              <string>Check V2Ray Core Settings</string>
             </property>
            </widget>
           </item>
-          <item row="8" column="0" colspan="2">
+          <item row="9" column="0" colspan="2">
            <widget class="QPushButton" name="pushButton">
             <property name="text">
              <string>Check System Date and Time from the Internet</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="label_68">
             <property name="text">
              <string>V2Ray API Subsystem</string>
@@ -827,14 +863,14 @@ Qv2ray will give a more accurate latency value if Enabled, but makes it easy to 
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QCheckBox" name="enableAPI">
             <property name="text">
              <string>Enabled</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="label_8">
             <property name="text">
              <string>V2Ray API Port</string>
@@ -844,7 +880,7 @@ Qv2ray will give a more accurate latency value if Enabled, but makes it easy to 
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QSpinBox" name="statsPortBox">
             <property name="minimumSize">
              <size>
@@ -863,14 +899,14 @@ Qv2ray will give a more accurate latency value if Enabled, but makes it easy to 
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="label_37">
             <property name="text">
              <string>Outbound Statistics (V2Ray Core v4.26+)</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="6" column="1">
            <widget class="QCheckBox" name="V2RayOutboundStatsCB">
             <property name="toolTip">
              <string>Currently:
@@ -883,14 +919,14 @@ Qv2ray will give a more accurate latency value if Enabled, but makes it easy to 
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="7" column="0">
            <widget class="QLabel" name="label_31">
             <property name="text">
              <string>Include Direct Connection</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
+          <item row="7" column="1">
            <widget class="QCheckBox" name="hasDirectStatisticsCB">
             <property name="text">
              <string>Enabled</string>

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -1403,6 +1403,10 @@ For example, for updating subscriptions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Core Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>none</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
add `kernelConfig` option `coreVersion`, allow switching between v2ray v4 (also xray) and v5 cores, default to v5 core
remove QV2RAY_USE_V5_CORE and corresponding cmake options

This commit is motivated to support xray, which is now better maintained compared to v2ray. Without this commit, qv2ray throws "Configuration Error" upon xray connection due to incompatible cli args.